### PR TITLE
LpcIO: Add get_arch call in Main

### DIFF
--- a/LpcIO.p
+++ b/LpcIO.p
@@ -507,5 +507,8 @@ public ioctl_set_gigabyte_controller(in[], in_size, out[], out_size) {
 }
 
 main() {
+    if (get_arch() != ARCH_X64)
+        return STATUS_NOT_SUPPORTED;
+    
     return STATUS_SUCCESS;
 }


### PR DESCRIPTION
Otherwise loading the module into the driver doesn't work.  Seems to be the case for every other module in this repo.