### PR TITLE
Add AMDReset to read the S5_RESET_STATUS on AMD systems

### DIFF
--- a/AMDReset.p
+++ b/AMDReset.p
@@ -1,0 +1,143 @@
+//  PawnIO Modules - Modules for various hardware to be used with PawnIO.
+//  Copyright (C) 2025  Steve-Tech <me@stevetech.au>
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//  SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <pawnio.inc>
+
+/*
+Following documentation from https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git/commit/?id=b343579de7b250101e4ed6c354b4c1fa986973a7
+
+Random reboot issues
+====================
+When a random reboot occurs, the high-level reason for the reboot is stored
+in a register that will persist onto the next boot.
+
+There are 6 classes of reasons for the reboot:
+ * Software induced
+ * Power state transition
+ * Pin induced
+ * Hardware induced
+ * Remote reset
+ * Internal CPU event
+
+| Bit | Type     | Reason                                                     |
+|-----|----------|------------------------------------------------------------|
+| 0   | Pin      | thermal pin BP_THERMTRIP_L was tripped                     |
+| 1   | Pin      | power button was pressed for 4 seconds                     |
+| 2   | Pin      | shutdown pin was shorted                                   |
+| 4   | Remote   | remote ASF power off command was received                  |
+| 9   | Internal | internal CPU thermal limit was tripped                     |
+| 16  | Pin      | system reset pin BP_SYS_RST_L was tripped                  |
+| 17  | Software | software issued PCI reset                                  |
+| 18  | Software | software wrote 0x4 to reset control register 0xCF9         |
+| 19  | Software | software wrote 0x6 to reset control register 0xCF9         |
+| 20  | Software | software wrote 0xE to reset control register 0xCF9         |
+| 21  | Sleep    | ACPI power state transition occurred                       |
+| 22  | Pin      | keyboard reset pin KB_RST_L was asserted                   |
+| 23  | Internal | internal CPU shutdown event occurred                       |
+| 24  | Hardware | system failed to boot before failed boot timer expired     |
+| 25  | Hardware | hardware watchdog timer expired                            |
+| 26  | Remote   | remote ASF reset command was received                      |
+| 27  | Internal | an uncorrected error caused a data fabric sync flood event |
+| 29  | Internal | FCH and MP1 failed warm reset handshake                    |
+| 30  | Internal | a parity error occurred                                    |
+| 31  | Internal | a software sync flood event occurred                       |
+*/
+
+#define FCH_PM_BASE				0xFED80300
+#define FCH_PM_S5_RESET_STATUS	0xC0
+
+/// Read the PMx000000C0 (FCH::PM::S5_RESET_STATUS) register.
+///
+/// @param out = Value read
+/// @return An NTSTATUS
+NTSTATUS:amd_reset_status(&out) {
+    new NTSTATUS:status;
+
+    // Map 32bits of MMIO space
+    new VA:va = io_space_map(FCH_PM_BASE + FCH_PM_S5_RESET_STATUS, 32/8);
+    if (va == NULL) {
+        debug_print(''Failed to map MMIO space\n'');
+        return STATUS_NO_MEMORY;
+    }
+
+    // Read the reset status register
+    new reset_status;
+    status = virtual_read_dword(va, reset_status);
+    if (!NT_SUCCESS(status))
+        debug_print(''Failed to read reset status\n'');
+    else if (reset_status == 0xFFFFFFFF) {
+        debug_print(''Failed to read reset status\n'');
+        status = STATUS_UNSUCCESSFUL;
+    }
+
+    // Unmap MMIO space
+    io_space_unmap(va, 32/8);
+    if (!NT_SUCCESS(status)) {
+        debug_print(''Failed to unmap MMIO space\n'');
+        return status;
+    }
+    
+    out = reset_status;
+
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS:main() {
+    if (get_arch() != ARCH_X64)
+        return STATUS_NOT_SUPPORTED;
+
+    new vendor[4];
+    cpuid(0, 0, vendor);
+    if (!is_amd(vendor))
+        return STATUS_NOT_SUPPORTED;
+
+    new procinfo[4];
+    cpuid(1, 0, procinfo);
+
+    new family = ((procinfo[0] & 0x0FF00000) >> 20) + ((procinfo[0] & 0x0F00) >> 8);
+    new model = ((procinfo[0] & 0x0F0000) >> 12) + ((procinfo[0] & 0xF0) >> 4);
+
+    debug_print(''AMDReset: family: %x model: %x\n'', family, model);
+
+    // Check if the CPU is 17h (Zen) or newer
+    // This does seem to be supported on 16h CPUs, but the bit mapping is different.
+    if (family < 0x17)
+        return STATUS_NOT_SUPPORTED;
+
+    return STATUS_SUCCESS;
+}
+
+/// Read the PMx000000C0 (FCH::PM::S5_RESET_STATUS) register.
+///
+/// @param in Unused
+/// @param in_size Unused
+/// @param out [0] = The status register value
+/// @param out_size Must be 1
+/// @return An NTSTATUS
+forward NTSTATUS:ioctl_amd_reset_status(in[], in_size, out[], out_size);
+public NTSTATUS:ioctl_amd_reset_status(in[], in_size, out[], out_size) {
+    if (out_size < 1)
+        return STATUS_BUFFER_TOO_SMALL;
+
+    new NTSTATUS:status = amd_reset_status(out[0]);
+    if (!NT_SUCCESS(status))
+        return status;
+
+    return STATUS_SUCCESS;
+}

--- a/AMDReset.p
+++ b/AMDReset.p
@@ -64,7 +64,7 @@ There are 6 classes of reasons for the reboot:
 
 /// Read the PMx000000C0 (FCH::PM::S5_RESET_STATUS) register.
 ///
-/// @param out = Value read
+/// @param out Value read
 /// @return An NTSTATUS
 NTSTATUS:amd_reset_status(&out) {
     new NTSTATUS:status;
@@ -80,7 +80,7 @@ NTSTATUS:amd_reset_status(&out) {
     new reset_status;
     status = virtual_read_dword(va, reset_status);
     if (!NT_SUCCESS(status))
-        debug_print(''Failed to read reset status\n'');
+        debug_print(''Failed to read reset status: %x\n'', _:status);
     else if (reset_status == 0xFFFFFFFF) {
         debug_print(''Failed to read reset status\n'');
         status = STATUS_UNSUCCESSFUL;
@@ -135,9 +135,5 @@ public NTSTATUS:ioctl_amd_reset_status(in[], in_size, out[], out_size) {
     if (out_size < 1)
         return STATUS_BUFFER_TOO_SMALL;
 
-    new NTSTATUS:status = amd_reset_status(out[0]);
-    if (!NT_SUCCESS(status))
-        return status;
-
-    return STATUS_SUCCESS;
+    return amd_reset_status(out[0]);
 }

--- a/include/native.inc
+++ b/include/native.inc
@@ -157,8 +157,8 @@ stock operator-(VA:a, VA:b) {
 /// Map physical memory to virtual, which can be accessed by the `virtual_*`
 /// family of functions.
 ///
-/// @param pa Physical address, page aligned
-/// @param size Size to map, page aligned
+/// @param pa Physical address
+/// @param size Size to map
 /// @return Virtual address
 /// @retval 0 Mapping failed, not enough VA space
 /// @warning The mapping is a resource that must be freed (unmapped)
@@ -166,8 +166,8 @@ native VA:io_space_map(pa, size);
 
 /// Unmap IO space.
 ///
-/// @param pa Physical address, page aligned
-/// @param size Size to unmap, page aligned
+/// @param pa Physical address
+/// @param size Size to unmap
 native Void:io_space_unmap(VA:va, size);
 
 /// Read a byte from virtual memory.


### PR DESCRIPTION
Hi, my day job is a computer technician, and being able to read the reset/shutdown reason seems like it *might* be useful, although I kinda doubt it ever will.

This commit was what inspired this: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git/commit/?id=b343579de7b250101e4ed6c354b4c1fa986973a7

But proper documentation is usually in volume 5 in [AMD's Processor Programming Reference](https://www.amd.com/en/search/documentation/hub.html#q=PPR&sortCriteria=%40amd_release_date%20descending&f-amd_document_type=Programmer%20References). I've been using [this one](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/programmer-references/57228.zip), because it was the first one I clicked on.

I have also considered adding an ioctl to write `0x6` (warm reset) or `0xE` (cold reset) to IO Port `0xCF9`, but that seems slightly too dangerous. (For reference, a cold reset will 'place system in S5 state for 3 to 5 seconds').

Thanks,
Steve