### PR TITLE
SMBus Timing Improvements

### DIFF
--- a/SmbusI801.p
+++ b/SmbusI801.p
@@ -116,8 +116,8 @@
 
 #define SMBUS_LEN_SENTINEL (I2C_SMBUS_BLOCK_MAX + 1)
 
-// Timeout in Linux is 200ms
-#define MAX_TIMEOUT 200
+// A 32 byte block process at 10MHz is 62.3ms, 80ms should be plenty
+#define MAX_TIMEOUT 80
 
 // PCI slot addresses
 // In order of most to least common

--- a/SmbusI801.p
+++ b/SmbusI801.p
@@ -434,14 +434,13 @@ Void:i801_set_hstadd(addr, read_write)
 
 NTSTATUS:i801_simple_transaction(addr, hstcmd, read_write, command, in, &out, &hststs)
 {
-    new xact, size;
+    new xact, size = hstcmd;
 
     switch (command) {
     case I2C_SMBUS_QUICK:
         {
             i801_set_hstadd(addr, read_write);
             xact = I801_QUICK;
-            size = 0;
         }
     case I2C_SMBUS_BYTE:
         {
@@ -449,7 +448,6 @@ NTSTATUS:i801_simple_transaction(addr, hstcmd, read_write, command, in, &out, &h
             if (read_write == I2C_SMBUS_WRITE)
                 io_out_byte(SMBHSTCMD, hstcmd);
             xact = I801_BYTE;
-            size = 1;
         }
     case I2C_SMBUS_BYTE_DATA:
         {
@@ -458,7 +456,6 @@ NTSTATUS:i801_simple_transaction(addr, hstcmd, read_write, command, in, &out, &h
                 io_out_byte(SMBHSTDAT0, in);
             io_out_byte(SMBHSTCMD, hstcmd);
             xact = I801_BYTE_DATA;
-            size = 2;
         }
     case I2C_SMBUS_WORD_DATA:
         {
@@ -469,7 +466,6 @@ NTSTATUS:i801_simple_transaction(addr, hstcmd, read_write, command, in, &out, &h
             }
             io_out_byte(SMBHSTCMD, hstcmd);
             xact = I801_WORD_DATA;
-            size = 3;
         }
     case I2C_SMBUS_PROC_CALL:
         {
@@ -479,6 +475,7 @@ NTSTATUS:i801_simple_transaction(addr, hstcmd, read_write, command, in, &out, &h
             io_out_byte(SMBHSTCMD, hstcmd);
             read_write = I2C_SMBUS_READ;
             xact = I801_PROC_CALL;
+            // This doesn't follow the trend of the other commands matching their size
             size = 6
         }
     default:

--- a/SmbusPIIX4.p
+++ b/SmbusPIIX4.p
@@ -48,7 +48,6 @@
 #define I2C_SMBUS_I2C_BLOCK_DATA    8
 
 /* Other settings */
-#define MAX_TIMEOUT		500
 #define  ENABLE_INT9	0
 
 /* PIIX4 constants */
@@ -82,6 +81,9 @@
 #define SMBSLVEVT	(0x0A + piix4_smba)
 #define SMBSLVDAT	(0x0C + piix4_smba)
 #define SMBTIMING	(0x0E + piix4_smba)
+
+// A 32 byte block read at 10MHz is 32.5ms, 64ms should be plenty
+#define MAX_TIMEOUT 64
 
 new addresses[] = [0x0B00, 0x0B20];
 new piix4_smba = 0x0B00;

--- a/SmbusPIIX4.p
+++ b/SmbusPIIX4.p
@@ -232,8 +232,9 @@ NTSTATUS:piix4_transaction(size)
         debug_print(''Error: no response!\n'');
     }
 
-    if (io_in_byte(SMBHSTSTS) != 0x00)
-        io_out_byte(SMBHSTSTS, io_in_byte(SMBHSTSTS));
+    // Reset the status flags
+    if (temp != 0x00)
+        io_out_byte(SMBHSTSTS, temp);
 
     if ((temp = io_in_byte(SMBHSTSTS)) != 0x00) {
         debug_print(''Failed reset at end of transaction (%x)\n'', temp);

--- a/SmbusPIIX4.p
+++ b/SmbusPIIX4.p
@@ -210,6 +210,12 @@ NTSTATUS:piix4_transaction(size)
         temp = io_in_byte(SMBHSTSTS);
     } while ((get_tick_count() < deadline) && (temp & 0x01));
 
+    if (temp == 0x02) {
+        // Reset the status flags
+        io_out_byte(SMBHSTSTS, temp);
+        goto check_reset;
+    }
+
     /* If the SMBus is still busy, we give up */
     if (temp & 0x01) {
         debug_print(''SMBus Timeout!\n'');
@@ -236,6 +242,7 @@ NTSTATUS:piix4_transaction(size)
     if (temp != 0x00)
         io_out_byte(SMBHSTSTS, temp);
 
+check_reset:
     if ((temp = io_in_byte(SMBHSTSTS)) != 0x00) {
         debug_print(''Failed reset at end of transaction (%x)\n'', temp);
     }


### PR DESCRIPTION
Hi,

i801 now uses `microsleep2` for more accurate sleeping, and only delays for the theoretical minimum amount of time needed based on the number of bytes being transferred. i801 style controllers operate at a max of 100khz, and there isn't a way to read (or change?) the speed.

PIIX4 also now waits for the theoretical minimum amount of time based on clock speed and bytes transferred. My laptop (where I did the original benchmarking) seemed to run at ~392KHz, while my desktop runs at ~93KHz; so it's no longer hard coded to somewhat arbitrary values, and will adjust based on clock speed. Until SMBus 3.0, the max speed was 100KHz.

Both drivers now delay in the loop for one clock cycle, since that seems reasonable.

Here's the most relevant SMBus spec: https://www.smbus.org/specs/smbus20.pdf
Here's the latest SMBus spec: https://www.smbus.org/specs/SMBus_3_3_1_20241020.pdf

Thanks,
Steve