### PR TITLE
Allow additional ports 0x25c and 0x25d in is_port_allowed for EC mailbox

### DIFF
--- a/LpcIO.p
+++ b/LpcIO.p
@@ -157,6 +157,10 @@ bool:is_port_allowed(port) {
     if (port == g_register_port || port == g_register_port + 1)
         return true;
 
+    // Allow fixed ports 0x25C and 0x25D
+    if (port == 0x25C || port == 0x25D)
+        return true;
+
     // we assume that each BAR is a range of 8 bytes at most
     new port_clamped = port & 0xFFF8;
     new bool:valid = false;

--- a/LpcIO.p
+++ b/LpcIO.p
@@ -157,7 +157,9 @@ bool:is_port_allowed(port) {
     if (port == g_register_port || port == g_register_port + 1)
         return true;
 
-    // Allow fixed ports 0x25C and 0x25D
+    // Allow fixed ports 0x25C and 0x25D for ASUS EC
+    // Please keep in mind that the official AsusSAIO driver holds a kernel MUTEX, which usermode can't possibly
+    // acquire, so it is recommended that you make sure that the official driver is unloaded when poking these.
     if (port == 0x25C || port == 0x25D)
         return true;
 


### PR DESCRIPTION
Hey there namazso,

This PR adds the ports 0x25C 0x25D for the EC mailbox on Asus laptops, for fan control and various other functions.

```
// Allow fixed ports 0x25C and 0x25D
    if (port == 0x25C || port == 0x25D)
        return true;
```