### PR TITLE
SmbusIntelSkylakeIMC: Support all addresses, remove special case hand…

### DIFF
--- a/SmbusIntelSkylakeIMC.p
+++ b/SmbusIntelSkylakeIMC.p
@@ -1,5 +1,5 @@
 //  PawnIO Modules - Modules for various hardware to be used with PawnIO.
-//  Copyright (C) 2026 Blacktempel
+//  Copyright (C) 2026 Blacktempel, Adam Honse <calcprogrammer1@gmail.com>
 //
 //  This library is free software; you can redistribute it and/or
 //  modify it under the terms of the GNU Lesser General Public
@@ -48,16 +48,15 @@
 
 //Bits in CMD
 #define WORD_BIT            0x00020000
+#define SEL_PTR_BIT         0x00040000
 #define WRITE_OPERATION     0x00008000
 #define GO_BIT              0x00080000
 #define TSOD_ACTIVE_BIT     0x00100000
 #define COMMAND_TOGGLE_BIT  0x20000000
 #define COMMAND_KEEP_MASK   0xFFEFFFFF
 #define COMMAND_PREFIX      0x20080000
-#define PAGE_COMMAND        0x2008B6
 
-#define SLOT_SHIFT  8
-#define OP_SHIFT    11
+#define ADDR_SHIFT      8
 
 //Status bits
 #define STS_BUSY        0x1
@@ -67,23 +66,13 @@
 #define STS_ANY_DONE    (STS_ERROR | STS_READ_DONE | STS_WRITE_DONE)
 #define STS_STATE_MASK  0x7
 
-#define START_RETRIES               5
 #define PAGE_STATUS_RETRIES         9999
 #define PAGE_COMMAND_RETRIES        999
 #define TRANSFER_STATUS_RETRIES     99999
 #define TRANSFER_TOGGLE_RETRIES     9999
 
-
 #define MAX_SMBUS_CONTROLLERS 2
 #define ADDRESS_SPACE_8BIT_SIZE 0x100
-
-#define SPD_BEGIN              0x50
-#define SPD_END                0x57
-#define SPD_DDR4_ADDRESS_PAGE  0x36
-#define SPD_OPCODE             0x0A
-#define TSOD_OPCODE            0x03
-#define DDR4_TSOD_BEGIN        0x18
-#define DDR4_TSOD_END          0x1F
 
 #define CMD_REG CMD_BASE + smbus_index * REG_STEP
 #define STS_REG STS_BASE + smbus_index * REG_STEP
@@ -236,115 +225,10 @@ bool:WaitTransferComplete(expectedDoneBit, &lastStatus)
     return (lastStatus & doneMask) == expectedDoneBit;
 }
 
-bool:IsSPDDeviceAddress(addr)
+NTSTATUS:ImcAccess(command, read_write, addr, hstcmd, &value)
 {
-    return addr >= SPD_BEGIN && addr <= SPD_END;
-}
-
-bool:IsDDR4PageSelectorAddress(addr)
-{
-    return addr == SPD_DDR4_ADDRESS_PAGE || addr == SPD_DDR4_ADDRESS_PAGE + 1;
-}
-
-bool:IsDDR4TSODAddress(addr)
-{
-    return addr >= DDR4_TSOD_BEGIN && addr <= DDR4_TSOD_END;
-}
-
-NTSTATUS:PrepareImcTransfer(addr, command, hstcmd, &offset, &opcode, &slot)
-{
-    offset = 0;
-    opcode = 0;
-    slot = 0;
-
-    if (hstcmd != I2C_SMBUS_BYTE_DATA
-     && hstcmd != I2C_SMBUS_WORD_DATA)
-    {
-        return STATUS_NOT_SUPPORTED;
-    }
-
-    if (hstcmd == I2C_SMBUS_WORD_DATA && IsDDR4TSODAddress(addr))
-    {
-        offset = command & 0xFF;
-        opcode = TSOD_OPCODE;
-        slot = addr & 0x07;
-
-        return STATUS_SUCCESS;
-    }
-
-    if (hstcmd == I2C_SMBUS_BYTE_DATA && IsSPDDeviceAddress(addr))
-    {
-        offset = command & 0xFF;
-        opcode = SPD_OPCODE;
-        slot = addr & 0x07;
-
-        return STATUS_SUCCESS;
-    }
-
-    return STATUS_NOT_SUPPORTED;
-}
-
-NTSTATUS:SetBankCore(bankIndex)
-{
-    if (bankIndex < 0 || bankIndex > 1)
-    {
-        return STATUS_NO_SUCH_DEVICE;
-    }
-
-    for (new i = 0; i < START_RETRIES; i++)
-    {
-        new oldCommand = 0;
-        new NTSTATUS:status = pci_config_read_dword(pci_address[0], pci_address[1], pci_address[2], CMD_REG, oldCommand);
-        if (!NT_SUCCESS(status))
-        {
-            return status;
-        }
-
-        if (!ClearTsodStateIfNeeded(oldCommand))
-        {
-            continue;
-        }
-
-        new cmd = ((bankIndex & 1) | PAGE_COMMAND) << 8;
-
-        status = pci_config_write_dword(pci_address[0], pci_address[1], pci_address[2], CMD_REG, cmd);
-        if (!NT_SUCCESS(status))
-        {
-            return status;
-        }
-
-        new lastStatus = 0;
-        new bool:completed = false;
-        for (new j = 0; j < PAGE_STATUS_RETRIES; j++)
-        {
-            status = pci_config_read_dword(pci_address[0], pci_address[1], pci_address[2], STS_REG, lastStatus);
-            if (!NT_SUCCESS(status))
-            {
-                break;
-            }
-
-            if ((lastStatus & 0x03) != STS_BUSY)
-            {
-                completed = true;
-                break;
-            }
-        }
-
-        pci_config_write_dword(pci_address[0], pci_address[1], pci_address[2], CMD_REG, oldCommand);
-
-        if (completed)
-        {
-            debug_print(''Set Bank index to %d\n'', bankIndex);
-            return STATUS_SUCCESS;
-        }
-    }
-
-    return STATUS_DEVICE_BUSY;
-}
-
-NTSTATUS:ImcAccess(offset, read_write, opcode, slot, hstcmd, &value)
-{
-    if (hstcmd != I2C_SMBUS_BYTE_DATA
+    if (hstcmd != I2C_SMBUS_BYTE
+     && hstcmd != I2C_SMBUS_BYTE_DATA
      && hstcmd != I2C_SMBUS_WORD_DATA)
     {
         debug_print(''Unsupported transaction %d\n'', hstcmd);
@@ -356,91 +240,91 @@ NTSTATUS:ImcAccess(offset, read_write, opcode, slot, hstcmd, &value)
         return STATUS_INVALID_PARAMETER;
     }
 
-    for (new i = 0; i < START_RETRIES; i++)
+    new oldCommand = 0;
+    new NTSTATUS:status = pci_config_read_dword(pci_address[0], pci_address[1], pci_address[2], CMD_REG, oldCommand);
+    if (!NT_SUCCESS(status))
     {
-        new oldCommand = 0;
-        new NTSTATUS:status = pci_config_read_dword(pci_address[0], pci_address[1], pci_address[2], CMD_REG, oldCommand);
-        if (!NT_SUCCESS(status))
-        {
-            return status;
-        }
+        return status;
+    }
 
-        if (!ClearTsodStateIfNeeded(oldCommand))
-        {
-            continue;
-        }
+    if (!ClearTsodStateIfNeeded(oldCommand))
+    {
+        return STATUS_DEVICE_BUSY;
+    }
 
-        new cmd = COMMAND_PREFIX
-                | ((opcode & 0xF) << OP_SHIFT)
-                | ((slot & 0x7) << SLOT_SHIFT)
-                | offset;
+    new cmd = COMMAND_PREFIX
+            | (addr & 0xFF) << ADDR_SHIFT
+            | (command & 0xFF) ;
+
+    if (hstcmd == I2C_SMBUS_BYTE)
+    {
+        cmd |= SEL_PTR_BIT;
+    }
+
+    if (hstcmd == I2C_SMBUS_WORD_DATA)
+    {
+        cmd |= WORD_BIT;
+    }
+
+    if (read_write == I2C_SMBUS_WRITE)
+    {
+        new writeData = value & 0xFF;
 
         if (hstcmd == I2C_SMBUS_WORD_DATA)
         {
-            cmd |= WORD_BIT;
+            writeData = ((value & 0xFF00) >> 8) | ((value & 0x00FF) << 8);
         }
 
-        if (read_write == I2C_SMBUS_WRITE)
-        {
-            new writeData = value & 0xFF;
-
-            if (hstcmd == I2C_SMBUS_WORD_DATA)
-            {
-                writeData = ((value & 0xFF00) >> 8) | ((value & 0x00FF) << 8);
-            }
-
-            status = pci_config_write_dword(pci_address[0], pci_address[1], pci_address[2], DAT_REG, writeData << 16);
-            if (!NT_SUCCESS(status))
-            {
-                return status;
-            }
-
-            cmd |= WRITE_OPERATION;
-        }
-
-        status = pci_config_write_dword(pci_address[0], pci_address[1], pci_address[2], CMD_REG, cmd);
+        status = pci_config_write_dword(pci_address[0], pci_address[1], pci_address[2], DAT_REG, writeData << 16);
         if (!NT_SUCCESS(status))
         {
             return status;
         }
 
-        new lastStatus = 0;
-        new expectedDoneBit = read_write == I2C_SMBUS_WRITE ? STS_WRITE_DONE : STS_READ_DONE;
-        if (WaitTransferComplete(expectedDoneBit, lastStatus))
+        cmd |= WRITE_OPERATION;
+    }
+
+    status = pci_config_write_dword(pci_address[0], pci_address[1], pci_address[2], CMD_REG, cmd);
+    if (!NT_SUCCESS(status))
+    {
+        return status;
+    }
+
+    new lastStatus = 0;
+    new expectedDoneBit = read_write == I2C_SMBUS_WRITE ? STS_WRITE_DONE : STS_READ_DONE;
+    if (WaitTransferComplete(expectedDoneBit, lastStatus))
+    {
+        if (read_write == I2C_SMBUS_WRITE)
         {
-            if (read_write == I2C_SMBUS_WRITE)
-            {
-                pci_config_write_dword(pci_address[0], pci_address[1], pci_address[2], CMD_REG, oldCommand);
-                return STATUS_SUCCESS;
-            }
-
-            new dataReg = 0;
-            status = pci_config_read_dword(pci_address[0], pci_address[1], pci_address[2], DAT_REG, dataReg);
             pci_config_write_dword(pci_address[0], pci_address[1], pci_address[2], CMD_REG, oldCommand);
-
-            if (!NT_SUCCESS(status))
-            {
-                return status;
-            }
-
-            switch (hstcmd)
-            {
-                case I2C_SMBUS_BYTE_DATA:
-                {
-                    value = dataReg & 0xFF;
-                    return STATUS_SUCCESS;
-                }
-                case I2C_SMBUS_WORD_DATA:
-                {
-                    //Swap high / low
-                    value = ((dataReg & 0xFF00) >> 8) | ((dataReg & 0x00FF) << 8);
-                    return STATUS_SUCCESS;
-                }
-            }
+            return STATUS_SUCCESS;
         }
 
+        new dataReg = 0;
+        status = pci_config_read_dword(pci_address[0], pci_address[1], pci_address[2], DAT_REG, dataReg);
         pci_config_write_dword(pci_address[0], pci_address[1], pci_address[2], CMD_REG, oldCommand);
+
+        if (!NT_SUCCESS(status))
+        {
+            return status;
+        }
+
+        if( hstcmd == I2C_SMBUS_BYTE
+         || hstcmd == I2C_SMBUS_BYTE_DATA)
+        {
+            value = dataReg & 0xFF;
+            return STATUS_SUCCESS;
+        }
+
+        if(hstcmd == I2C_SMBUS_WORD_DATA)
+        {
+            //Swap high / low
+            value = ((dataReg & 0xFF00) >> 8) | ((dataReg & 0x00FF) << 8);
+            return STATUS_SUCCESS;
+        }
     }
+
+    pci_config_write_dword(pci_address[0], pci_address[1], pci_address[2], CMD_REG, oldCommand);
 
     return STATUS_DEVICE_BUSY;
 }
@@ -450,12 +334,9 @@ NTSTATUS:ImcAccess(offset, read_write, opcode, slot, hstcmd, &value)
 /// Performs a transfer of data over the SMBus using the specified command.
 /// I2C_SMBUS_BYTE_DATA (2)
 /// I2C_SMBUS_WORD_DATA (3)
-/// I2C_SMBUS_BLOCK_DATA (5)
-/// I2C_SMBUS_I2C_BLOCK_DATA (8)
 ///
-/// @param in [0] = SMBus address, [1] = Read(1)/Write(0), [2] = Command/register offset, [3] = Protocol, [4] = Block length, [5..8] = Packed block write data bytes
-/// @param in_size Must be 9
-/// @param out [0] = Data for byte/word reads or block length for block reads, [1..4] = Packed block data bytes
+/// @param in [0] = Address, [1] = Read(1)/Write(0), [2] = Command, [3] = Protocol, [4] Data
+/// @param out [0] = Read data
 /// @param out_size Must be 5
 /// @return An NTSTATUS
 /// @warning You should acquire the "\BaseNamedObjects\Access_SMBUS.HTP.Method" mutant before calling this
@@ -465,104 +346,17 @@ DEFINE_IOCTL_SIZED(ioctl_smbus_xfer, 9, 5)
     new read_write = in[1];
     new command = in[2];
     new hstcmd = in[3];
-    new length = in[4];
 
-    if (IsDDR4PageSelectorAddress(addr))
+    // This controller does not appear to support QUICK or BLOCK operations
+    if (hstcmd == I2C_SMBUS_QUICK
+     || hstcmd == I2C_SMBUS_BLOCK_DATA
+     || hstcmd == I2C_SMBUS_I2C_BLOCK_DATA)
     {
-        if (read_write != I2C_SMBUS_WRITE)
-        {
-            return STATUS_NOT_SUPPORTED;
-        }
-
-        if (hstcmd == I2C_SMBUS_QUICK || hstcmd == I2C_SMBUS_BYTE_DATA)
-        {
-            return SetBankCore(addr - SPD_DDR4_ADDRESS_PAGE);
-        }
-
         return STATUS_NOT_SUPPORTED;
     }
 
-    if (hstcmd == I2C_SMBUS_BLOCK_DATA
-     || hstcmd == I2C_SMBUS_I2C_BLOCK_DATA)
-    {
-        if (read_write != I2C_SMBUS_READ && read_write != I2C_SMBUS_WRITE)
-        {
-            return STATUS_INVALID_PARAMETER;
-        }
-
-        if (length <= 0 || length > I2C_SMBUS_BLOCK_MAX)
-        {
-            return STATUS_INVALID_PARAMETER;
-        }
-
-        if (command + length > ADDRESS_SPACE_8BIT_SIZE)
-        {
-            return STATUS_INVALID_PARAMETER;
-        }
-
-        out[0] = 0;
-        out[1] = 0;
-        out[2] = 0;
-        out[3] = 0;
-        out[4] = 0;
-
-        for (new index = 0; index < length; index++)
-        {
-            new offset = 0;
-            new opcode = 0;
-            new slot = 0;
-
-            new NTSTATUS:status = PrepareImcTransfer(addr, command + index, I2C_SMBUS_BYTE_DATA, offset, opcode, slot);
-            if (!NT_SUCCESS(status))
-            {
-                return status;
-            }
-
-            new value = 0;
-
-            if (read_write == I2C_SMBUS_READ)
-            {
-                status = ImcAccess(offset, I2C_SMBUS_READ, opcode, slot, I2C_SMBUS_BYTE_DATA, value);
-                if (!NT_SUCCESS(status))
-                {
-                    return status;
-                }
-
-                new cellIndex = index / 8;
-                new byteOffset = index % 8;
-
-                out[1 + cellIndex] |= (value & 0xFF) << (byteOffset * 8);
-                out[0] = index + 1;
-            }
-            else
-            {
-                new cellIndex = index / 8;
-                new byteOffset = index % 8;
-
-                value = (in[5 + cellIndex] >> (byteOffset * 8)) & 0xFF;
-
-                status = ImcAccess(offset, I2C_SMBUS_WRITE, opcode, slot, I2C_SMBUS_BYTE_DATA, value);
-                if (!NT_SUCCESS(status))
-                {
-                    return status;
-                }
-            }
-        }
-
-        return STATUS_SUCCESS;
-    }
-
-    new offset = 0;
-    new opcode = 0;
-    new slot = 0;
-    new NTSTATUS:status = PrepareImcTransfer(addr, command, hstcmd, offset, opcode, slot);
-    if (!NT_SUCCESS(status))
-    {
-        return status;
-    }
-
-    new value = 0;
-    status = ImcAccess(offset, read_write, opcode, slot, hstcmd, value);
+    new value = in[4];
+    new NTSTATUS:status = ImcAccess(command, read_write, addr, hstcmd, value);
     if (!NT_SUCCESS(status))
     {
         return status;
@@ -570,18 +364,6 @@ DEFINE_IOCTL_SIZED(ioctl_smbus_xfer, 9, 5)
 
     out[0] = value;
     return STATUS_SUCCESS;
-}
-
-/// Set the bank index.
-///
-/// @param in [0] Bank index (0 or 1)
-/// @param in_size Must be 1
-/// @param out [0] Unused
-/// @param out_size Unused
-/// @return An NTSTATUS
-DEFINE_IOCTL_SIZED(ioctl_set_bank, 1, 0)
-{
-    return SetBankCore(in[0]);
 }
 
 /// Identify the SMBus controller.


### PR DESCRIPTION
Edit:  The scope of this PR changed as I worked it, so here's a full summary of what is changed.  This PR is ready to merge.

* The initial controller only supported accessing SPD and temperature sensor addresses, now it can access all addresses
* Special handling for SPD and temperature sensor addresses has been removed now that it can just access arbitrary addresses
* After reviewing the closest datasheet @Blacktempel could find to the actual hardware, it does not appear that SMBus Quick or Block operations are properly supportable on this implementation.  The existing block operations were actually performing a loop of repeated byte operations, which is not a compatible replacement on many devices.  It is best to just omit these unsupported operations entirely rather than exposing to userspace something that isn't accurate.
* The operations that I have implemented (read/write byte, byte data, and word data) have all been verified with an oscilloscope to be performing the correct operations.
* Leaving the ioctl argument sizes the same even though block operations are not supported so this module remains drop-in compatible with the other SMBus drivers in this repo.

Original description:
Based on the investigations I am working on in the comments of #60, I have removed a lot of the SPD special-case handling in this SMBus driver and instead opened up the range of allowed addresses to cover the full I2C address range.  This has been successful in my testing with OpenRGB, though still limited by the limited supported operations.  Namely, I can still bank switch the SPD by peforming a read operation on either 0x36 or 0x37 before dumping the SPD address.  There seems to be some extra addresses being picked up by my I2C detection probes still and I'm not sure why, so consider this still WIP until I unmark Draft.