### PR TITLE
AMDFamily17, IntelMSR: allow hardware-prefetcher / cache configuration MSRs

### DIFF
--- a/AMDFamily17.p
+++ b/AMDFamily17.p
@@ -53,6 +53,13 @@
 #define MSR_AMD_CPPC_REQ            (0xC00102B3)
 #define MSR_AMD_CPPC_STATUS         (0xC00102B4)
 
+// Load-store / cache / instruction-fetch configuration (AMD PPR, family 17h-1Ah).
+// These hold the hardware prefetcher and speculation controls used for CPU tuning.
+#define MSR_LS_CFG                  (0xC0011020)
+#define MSR_IC_CFG                  (0xC0011021)
+#define MSR_DC_CFG                  (0xC0011022)
+#define MSR_LS_CFG2                 (0xC001102B)
+
 #define SMN_INDEX_OFFSET	(0x60)
 #define SMN_DATA_OFFSET		(0x64)
 
@@ -68,7 +75,8 @@ bool:is_allowed_msr_read(msr) {
              MSR_PMGT_MISC, MSR_HARDWARE_PSTATE_STATUS, MSR_CSTATE_CONFIG,
              MSR_PWR_UNIT, MSR_CORE_ENERGY_STAT, MSR_PKG_ENERGY_STAT,
              MSR_AMD_CPPC_CAP1, MSR_AMD_CPPC_ENABLE, MSR_AMD_CPPC_CAP2,
-             MSR_AMD_CPPC_REQ, MSR_AMD_CPPC_STATUS:
+             MSR_AMD_CPPC_REQ, MSR_AMD_CPPC_STATUS,
+             MSR_LS_CFG, MSR_IC_CFG, MSR_DC_CFG, MSR_LS_CFG2:
             return true;
         default:
             return false;
@@ -82,7 +90,8 @@ bool:is_allowed_msr_write(msr) {
              MSR_PSTATE_0, MSR_PSTATE_1, MSR_PSTATE_2, MSR_PSTATE_3,
              MSR_PSTATE_4, MSR_PSTATE_5, MSR_PSTATE_6, MSR_PSTATE_7,
              MSR_PMGT_MISC, MSR_CSTATE_CONFIG, MSR_AMD_CPPC_ENABLE,
-             MSR_AMD_CPPC_REQ, MSR_AMD_CPPC_STATUS:
+             MSR_AMD_CPPC_REQ, MSR_AMD_CPPC_STATUS,
+             MSR_LS_CFG, MSR_IC_CFG, MSR_DC_CFG, MSR_LS_CFG2:
             return true;
         default:
             return false;

--- a/IntelMSR.p
+++ b/IntelMSR.p
@@ -63,6 +63,10 @@
 
 #define MSR_OC_MAILBOX          0x00000150
 
+// Hardware prefetcher controls (Intel SDM Vol. 4): bit 0 L2 HW prefetcher, bit 1 L2
+// adjacent-line, bit 2 DCU, bit 3 DCU IP. Used for CPU tuning.
+#define MSR_MISC_FEATURE_CONTROL    0x000001a4
+
 bool:is_allowed_msr_read(msr) {
     switch (msr) {
         case MSR_IA32_PACKAGE_THERM_STATUS, MSR_IA32_PERF_STATUS, MSR_IA32_TEMPERATURE_TARGET,
@@ -73,7 +77,8 @@ bool:is_allowed_msr_read(msr) {
             MSR_PP0_POWER_LIMIT, MSR_PP0_ENERGY_STATUS, MSR_PP0_POLICY, MSR_PP0_PERF_STATUS,
             MSR_PP1_POWER_LIMIT, MSR_PP1_ENERGY_STATUS, MSR_PP1_POLICY,
             MSR_PLATFORM_ENERGY_STATUS, MSR_RAPL_POWER_UNIT, MSR_PLATFORM_INFO,
-            MSR_EBL_CR_POWERON, MSR_TURBO_RATIO_LIMIT, MSR_OC_MAILBOX, MSR_VR_MAILBOX_INTERFACE, MSR_VR_MAILBOX_DATA:
+            MSR_EBL_CR_POWERON, MSR_TURBO_RATIO_LIMIT, MSR_OC_MAILBOX, MSR_VR_MAILBOX_INTERFACE, MSR_VR_MAILBOX_DATA,
+            MSR_MISC_FEATURE_CONTROL:
             return true;
         default:
             return false;
@@ -83,7 +88,8 @@ bool:is_allowed_msr_read(msr) {
 
 bool:is_allowed_msr_write(msr) {
     switch (msr) {
-        case MSR_VR_CURRENT_CONFIG, MSR_PKG_POWER_LIMIT, MSR_OC_MAILBOX, MSR_VR_MAILBOX_INTERFACE, MSR_VR_MAILBOX_DATA:
+        case MSR_VR_CURRENT_CONFIG, MSR_PKG_POWER_LIMIT, MSR_OC_MAILBOX, MSR_VR_MAILBOX_INTERFACE, MSR_VR_MAILBOX_DATA,
+             MSR_MISC_FEATURE_CONTROL:
             return true;
         default:
             return false;


### PR DESCRIPTION
This adds the documented hardware-prefetcher, load-store, and cache **configuration** MSRs to the
`AMDFamily17` and `IntelMSR` allow-lists so they can be read and written for CPU tuning — the same
kind of thing the modules already expose for P-state / HWCR / power-limit registers.

### What changed

**`AMDFamily17.p`** — added to both `is_allowed_msr_read` and `is_allowed_msr_write`:

| MSR | Addr | AMD PPR name |
|---|---|---|
| `MSR_LS_CFG`   | `0xC0011020` | Load-Store Configuration |
| `MSR_IC_CFG`   | `0xC0011021` | Instruction Cache Configuration |
| `MSR_DC_CFG`   | `0xC0011022` | Data Cache Configuration |
| `MSR_LS_CFG2`  | `0xC001102B` | Load-Store Configuration 2 |

(AMD PPR for family 17h–1Ah; these registers hold the hardware prefetcher and speculation controls.)

**`IntelMSR.p`** — added to both allow-lists:

| MSR | Addr | Intel SDM name |
|---|---|---|
| `MSR_MISC_FEATURE_CONTROL` | `0x1A4` | Misc. feature control — L2 HW / adjacent-line / DCU / DCU-IP prefetcher enables (bits 0–3) |

### Why

These are the standard, vendor-documented registers for toggling the hardware prefetchers and
related load/store behaviour. They're useful for tuning memory-latency-sensitive workloads, where
the prefetchers can hurt throughput on random-access patterns. Right now there's no signed way to
touch them on a modern (Secure Boot / HVCI) Windows box without an unsafe WinRing0-style driver —
which is exactly what PawnIO is meant to replace.

### Safety / scope

- Gated through the existing `is_allowed_msr_read` / `is_allowed_msr_write` switches — **no arbitrary
  MSR access** is introduced; only these specific, documented config registers are permitted, exactly
  as the modules already gate writes to the P-state, HWCR, CSTATE, CPPC, and power-limit MSRs.
- AMD reads are additionally gated by the module's existing `family 0x17–0x1A` check; Intel by the
  `CpuVendor_Intel` check.
- No new IOCTLs, no new natives, no behavioural change to existing reads/writes. LGPL-2.1, no new
  warnings.

Happy to adjust naming, split the AMD/Intel changes, or narrow the set if you'd prefer.
