### PR TITLE
RyzenSMU: Remove unnecessary io space map in main

### DIFF
--- a/RyzenSMU.p
+++ b/RyzenSMU.p
@@ -481,29 +481,6 @@ NTSTATUS:map_pm_table(table_base) {
     return STATUS_SUCCESS;
 }
 
-NTSTATUS:init_pm_table() {
-    new version;
-    new NTSTATUS:status = get_pm_table_version(version);
-    if (!NT_SUCCESS(status))
-        return status;
-    debug_print(''RyzenSMU: PM Table Version: %x\n'', version);
-
-    new table_base;
-    status = get_pm_table_base(table_base);
-    if (!NT_SUCCESS(status))
-        return status;
-    debug_print(''RyzenSMU: PM Table Base: %x\n'', table_base);
-
-    if (!g_table_va || g_table_base != table_base) {
-        status = map_pm_table(table_base);
-        if (!NT_SUCCESS(status))
-            return status;
-    }
-
-    g_table_version = version;
-    return STATUS_SUCCESS;
-}
-
 NTSTATUS:check_smu_register_range(cmd) {
     if (cmd < 0 || cmd > 0xFFFFFFFF) return STATUS_NOT_SUPPORTED;
 
@@ -534,9 +511,20 @@ NTSTATUS:check_smu_register_range(cmd) {
 /// @return An NTSTATUS
 /// @warning You should acquire the "\BaseNamedObjects\Access_PCI" mutant before calling this
 DEFINE_IOCTL_SIZED(ioctl_resolve_pm_table, 0, 2) {
-    new NTSTATUS:status = init_pm_table();
+    new version;
+    new NTSTATUS:status = get_pm_table_version(version);
     if (!NT_SUCCESS(status))
         return status;
+    debug_print(''RyzenSMU: PM Table Version: %x\n'', version);
+
+    new table_base;
+    status = get_pm_table_base(table_base);
+    if (!NT_SUCCESS(status))
+        return status;
+    debug_print(''RyzenSMU: PM Table Base: %x\n'', table_base);
+
+    g_table_version = version;
+    g_table_base = table_base;
 
     out[0] = g_table_version;
     out[1] = g_table_base;
@@ -566,8 +554,15 @@ DEFINE_IOCTL_SIZED(ioctl_update_pm_table, 0, 0) {
 DEFINE_IOCTL(ioctl_read_pm_table) {
     if (out_size < 1)
         return STATUS_BUFFER_TOO_SMALL;
-    if (!g_table_base || !g_table_va)
+
+    if (!g_table_base)
         return STATUS_DEVICE_NOT_READY;
+
+    if (!g_table_va) {
+        new NTSTATUS:map_status = map_pm_table(g_table_base);
+        if (!NT_SUCCESS(map_status))
+            return map_status;
+    }
 
     new read_count = min(out_size, g_table_size / 8);
     new NTSTATUS:status = STATUS_SUCCESS;
@@ -725,10 +720,6 @@ NTSTATUS:main() {
         return STATUS_NOT_SUPPORTED;
 
     g_code_name = code_name;
-
-    new NTSTATUS:map_status = init_pm_table();
-    if (!NT_SUCCESS(map_status))
-        return map_status;
 
     return STATUS_SUCCESS;
 }

--- a/RyzenSMU.p
+++ b/RyzenSMU.p
@@ -453,18 +453,14 @@ NTSTATUS:get_pm_table_base(&base) {
 }
 
 new g_table_base;
-new g_table_version;
 new VA:g_table_va = NULL;
-new g_table_size;
 
 unmap_pm_table() {
     if (g_table_va) {
-        io_space_unmap(g_table_va, g_table_size);
+        io_space_unmap(g_table_va, PAGE_SIZE);
         g_table_va = NULL;
     }
-    g_table_size = 0;
     g_table_base = 0;
-    g_table_version = 0;
 }
 
 NTSTATUS:map_pm_table(table_base) {
@@ -476,7 +472,6 @@ NTSTATUS:map_pm_table(table_base) {
         return STATUS_COMMITMENT_LIMIT;
 
     g_table_va = table_va;
-    g_table_size = PAGE_SIZE;
     g_table_base = table_base;
     return STATUS_SUCCESS;
 }
@@ -523,11 +518,10 @@ DEFINE_IOCTL_SIZED(ioctl_resolve_pm_table, 0, 2) {
         return status;
     debug_print(''RyzenSMU: PM Table Base: %x\n'', table_base);
 
-    g_table_version = version;
     g_table_base = table_base;
 
-    out[0] = g_table_version;
-    out[1] = g_table_base;
+    out[0] = version;
+    out[1] = table_base;
 
     return STATUS_SUCCESS;
 }
@@ -564,7 +558,7 @@ DEFINE_IOCTL(ioctl_read_pm_table) {
             return map_status;
     }
 
-    new read_count = min(out_size, g_table_size / 8);
+    new read_count = min(out_size, PAGE_SIZE / 8);
     new NTSTATUS:status = STATUS_SUCCESS;
     new read;
     for (new i = 0; i < read_count; ++i) {


### PR DESCRIPTION
I don't know how I messed this up, but the current version of the module has wrong logic as it maps the space on module load, which is really not desired. Not only this, but it would require pci mutex lock on module load due to the `get_pm_table_version` which sends a smu command.

- Remove io map from main method
- Move memory address range map to `ioctl_read_pm_table`, but map only once and unmap on module unload in comparison with older versions of the module. This seems the correct approach for me as some clients might not need the pm table functionality at all.
- Remove `g_table_size` global var as that's not really needed at the moment, since the whole page window (`PAGE_SIZE`) is mapped. The real table size is not fetched.

Sorry for the possible incovenience caused for other projects using this module.