### PR TITLE
Add read-only NVIDIA GB202 thermal channels

### DIFF
--- a/NvidiaGB202Thermal.p
+++ b/NvidiaGB202Thermal.p
@@ -1,4 +1,4 @@
-// PawnIO module for NVIDIA GB202 thermal registers observed in HWMonitor 1.65.
+// PawnIO module for NVIDIA GB202 thermal registers observed in HWMonitor 1.65.1.
 // Copyright (C) 2026 Gonzalo Duque de Blas (@GDuqueB)
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -14,11 +14,11 @@
 #define PCI_BAR_MEM_TYPE_64BIT     0x04
 #define PCI_BAR_MEM_ADDR_MASK      0xFFFFFFF0
 
-// Both registers fit in this single 4 KiB page of BAR0.
+// All six thermal channels fit in this single 4 KiB page of BAR0.
 #define THERMAL_PAGE_OFFSET        0x00AD0000
 #define THERMAL_PAGE_SIZE          0x1000
-#define HOTSPOT_PAGE_OFFSET        0x0A90
-#define HOTSPOT_2_PAGE_OFFSET      0x0AE0
+#define THERMAL_CHANNELS_OFFSET    0x0A90
+#define THERMAL_CHANNEL_COUNT      6
 
 new VA:g_thermal_page_va = NULL;
 new g_pci_bdf = 0;
@@ -93,36 +93,33 @@ DEFINE_IOCTL_SIZED(ioctl_init, 1, 0) {
     return nvidia_thermal_init(bus, device, function);
 }
 
-/// Read the two read-only thermal registers used by HWMonitor 1.65 on GB202.
+/// Read the six contiguous thermal channels used by HWMonitor 1.65.1 on GB202.
+///
+/// HWMonitor 1.65.1 treats bit 30 as the validity flag and decodes a valid
+/// sample as (raw & 0xFFFF) / 256.0 degrees Celsius. Decoding remains the
+/// responsibility of the user-mode consumer; this module only returns raw data.
 ///
 /// @param in Unused
 /// @param in_size Must be 0
-/// @param out [0] = raw DWORD at BAR0 + 0x00AD0A90 (Hot Spot)
-///            [1] = raw DWORD at BAR0 + 0x00AD0AE0 (HotSpot #2)
-/// @param out_size Must be 2
+/// @param out Raw DWORDs from BAR0 + 0x00AD0A90 through 0x00AD0AA4.
+///            Channel 0 at 0x00AD0A90 is the Hot Spot value displayed by
+///            HWMonitor 1.65.1; channels 1-5 are additional thermal channels.
+/// @param out_size Must be 6
 /// @return An NTSTATUS
-DEFINE_IOCTL_SIZED(ioctl_read_thermal, 0, 2) {
+DEFINE_IOCTL_SIZED(ioctl_read_thermal, 0, 6) {
     if (g_thermal_page_va == NULL)
         return STATUS_DEVICE_NOT_READY;
 
-    new hotspot = 0;
-    new hotspot_2 = 0;
-    new NTSTATUS:status = virtual_read_dword(
-        g_thermal_page_va + HOTSPOT_PAGE_OFFSET,
-        hotspot
-    );
-    if (!NT_SUCCESS(status))
-        return status;
-
-    status = virtual_read_dword(
-        g_thermal_page_va + HOTSPOT_2_PAGE_OFFSET,
-        hotspot_2
-    );
-    if (!NT_SUCCESS(status))
-        return status;
-
-    out[0] = hotspot;
-    out[1] = hotspot_2;
+    for (new channel = 0; channel < THERMAL_CHANNEL_COUNT; channel++) {
+        new raw = 0;
+        new NTSTATUS:status = virtual_read_dword(
+            g_thermal_page_va + THERMAL_CHANNELS_OFFSET + channel * 4,
+            raw
+        );
+        if (!NT_SUCCESS(status))
+            return status;
+        out[channel] = raw;
+    }
     return STATUS_SUCCESS;
 }
 

--- a/NvidiaGB202Thermal.p
+++ b/NvidiaGB202Thermal.p
@@ -1,0 +1,164 @@
+// PawnIO module for NVIDIA GB202 thermal registers observed in HWMonitor 1.65.
+// Copyright (C) 2026 Gonzalo Duque de Blas (@GDuqueB)
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <pawnio.inc>
+
+#define PCI_VENDOR_ID_NVIDIA       0x10DE
+#define PCI_DEVICE_ID_RTX_5090     0x2B85
+
+#define PCI_CFG_BAR0_LOW           0x10
+#define PCI_CFG_BAR0_HIGH          0x14
+#define PCI_BAR_IO_SPACE           0x01
+#define PCI_BAR_MEM_TYPE_MASK      0x06
+#define PCI_BAR_MEM_TYPE_64BIT     0x04
+#define PCI_BAR_MEM_ADDR_MASK      0xFFFFFFF0
+
+// Both registers fit in this single 4 KiB page of BAR0.
+#define THERMAL_PAGE_OFFSET        0x00AD0000
+#define THERMAL_PAGE_SIZE          0x1000
+#define HOTSPOT_PAGE_OFFSET        0x0A90
+#define HOTSPOT_2_PAGE_OFFSET      0x0AE0
+
+new VA:g_thermal_page_va = NULL;
+new g_pci_bdf = 0;
+new g_vid_did = 0;
+
+NTSTATUS:nvidia_thermal_init(bus, device, function) {
+    if (bus < 0 || bus > 0xFF || device < 0 || device > 0x1F || function < 0 || function > 7)
+        return STATUS_INVALID_PARAMETER;
+
+    new vid_did = 0;
+    new NTSTATUS:status = pci_config_read_dword(bus, device, function, 0, vid_did);
+    if (!NT_SUCCESS(status))
+        return status;
+    if ((vid_did & 0xFFFF) != PCI_VENDOR_ID_NVIDIA)
+        return STATUS_NOT_SUPPORTED;
+    if (((vid_did >> 16) & 0xFFFF) != PCI_DEVICE_ID_RTX_5090)
+        return STATUS_NOT_SUPPORTED;
+
+    new base_lo = 0;
+    new base_hi = 0;
+    status = pci_config_read_dword(bus, device, function, PCI_CFG_BAR0_LOW, base_lo);
+    if (!NT_SUCCESS(status))
+        return status;
+    if (base_lo == 0 || base_lo == 0xFFFFFFFF || (base_lo & PCI_BAR_IO_SPACE))
+        return STATUS_NOT_SUPPORTED;
+
+    new bar_type = base_lo & PCI_BAR_MEM_TYPE_MASK;
+    if (bar_type != 0 && bar_type != PCI_BAR_MEM_TYPE_64BIT)
+        return STATUS_NOT_SUPPORTED;
+
+    if (bar_type == PCI_BAR_MEM_TYPE_64BIT) {
+        status = pci_config_read_dword(bus, device, function, PCI_CFG_BAR0_HIGH, base_hi);
+        if (!NT_SUCCESS(status))
+            return status;
+    }
+
+    new bar0 = ((base_hi & 0xFFFFFFFF) << 32) | (base_lo & PCI_BAR_MEM_ADDR_MASK);
+    if (bar0 == 0)
+        return STATUS_NOT_SUPPORTED;
+
+    new thermal_page_pa = bar0 + THERMAL_PAGE_OFFSET;
+    new VA:thermal_page_va = io_space_map(thermal_page_pa, THERMAL_PAGE_SIZE);
+    if (thermal_page_va == NULL)
+        return STATUS_INSUFFICIENT_RESOURCES;
+
+    g_thermal_page_va = thermal_page_va;
+    g_pci_bdf = (bus << 16) | (device << 8) | function;
+    g_vid_did = vid_did;
+    return STATUS_SUCCESS;
+}
+
+/// Validate an RTX 5090 at the supplied PCI address and map its thermal page.
+///
+/// @param in [0] = (bus << 16) | (device << 8) | function
+/// @param in_size Must be 1
+/// @param out Unused
+/// @param out_size Must be 0
+/// @return An NTSTATUS
+DEFINE_IOCTL_SIZED(ioctl_init, 1, 0) {
+    new bdf = in[0];
+    if (g_thermal_page_va != NULL) {
+        if (bdf == g_pci_bdf)
+            return STATUS_SUCCESS;
+        return STATUS_DEVICE_BUSY;
+    }
+
+    new bus = (bdf >> 16) & 0xFF;
+    new device = (bdf >> 8) & 0x1F;
+    new function = bdf & 0x07;
+    if (bdf != ((bus << 16) | (device << 8) | function))
+        return STATUS_INVALID_PARAMETER;
+    return nvidia_thermal_init(bus, device, function);
+}
+
+/// Read the two read-only thermal registers used by HWMonitor 1.65 on GB202.
+///
+/// @param in Unused
+/// @param in_size Must be 0
+/// @param out [0] = raw DWORD at BAR0 + 0x00AD0A90 (Hot Spot)
+///            [1] = raw DWORD at BAR0 + 0x00AD0AE0 (HotSpot #2)
+/// @param out_size Must be 2
+/// @return An NTSTATUS
+DEFINE_IOCTL_SIZED(ioctl_read_thermal, 0, 2) {
+    if (g_thermal_page_va == NULL)
+        return STATUS_DEVICE_NOT_READY;
+
+    new hotspot = 0;
+    new hotspot_2 = 0;
+    new NTSTATUS:status = virtual_read_dword(
+        g_thermal_page_va + HOTSPOT_PAGE_OFFSET,
+        hotspot
+    );
+    if (!NT_SUCCESS(status))
+        return status;
+
+    status = virtual_read_dword(
+        g_thermal_page_va + HOTSPOT_2_PAGE_OFFSET,
+        hotspot_2
+    );
+    if (!NT_SUCCESS(status))
+        return status;
+
+    out[0] = hotspot;
+    out[1] = hotspot_2;
+    return STATUS_SUCCESS;
+}
+
+/// Return the exact PCI identity and BAR0-relative page mapped by this module.
+///
+/// @param in Unused
+/// @param in_size Must be 0
+/// @param out [0] = (device ID << 16) | vendor ID
+///            [1] = (bus << 16) | (device << 8) | function
+///            [2] = BAR0-relative offset of the mapped thermal page
+///            [3] = mapped size
+/// @param out_size Must be 4
+/// @return An NTSTATUS
+DEFINE_IOCTL_SIZED(ioctl_identity, 0, 4) {
+    if (g_thermal_page_va == NULL)
+        return STATUS_DEVICE_NOT_READY;
+
+    out[0] = g_vid_did;
+    out[1] = g_pci_bdf;
+    out[2] = THERMAL_PAGE_OFFSET;
+    out[3] = THERMAL_PAGE_SIZE;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS:main() {
+    if (get_arch() != ARCH_X64)
+        return STATUS_NOT_SUPPORTED;
+    return STATUS_SUCCESS;
+}
+
+public NTSTATUS:unload() {
+    if (g_thermal_page_va != NULL) {
+        io_space_unmap(g_thermal_page_va, THERMAL_PAGE_SIZE);
+        g_thermal_page_va = NULL;
+    }
+    g_pci_bdf = 0;
+    g_vid_did = 0;
+    return STATUS_SUCCESS;
+}


### PR DESCRIPTION
## Summary

This PR adds a narrowly scoped PawnIO module for reading the six contiguous GB202 thermal channels used by HWMonitor 1.65.1 on the NVIDIA GeForce RTX 5090 (PCI ID `10DE:2B85`).

The module:

- accepts a caller-supplied PCI BDF and verifies the exact vendor/device ID;
- resolves BAR0 from PCI configuration space;
- maps only the 4 KiB page at BAR0-relative offset `0x00AD0000`;
- exposes six fixed read-only DWORDs from `0x00AD0A90` through `0x00AD0AA4`;
- provides no MMIO, PCI configuration, I/O-port, MSR, or physical-memory write primitive;
- supports x64 only and releases the mapping on unload.

## HWMonitor 1.65.1 correction

HWMonitor 1.65.1, released after the original submission, corrected its RTX 50 hotspot implementation. A static comparison with 1.65 shows that:

- `0x00AD0A90` remains the register used for the displayed Hot Spot value;
- `0x00AD0AE0`, previously interpreted as `HotSpot #2`, is no longer read;
- six channels are now read at `0x00AD0A90`, `0x00AD0A94`, `0x00AD0A98`, `0x00AD0A9C`, `0x00AD0AA0`, and `0x00AD0AA4`;
- bit 30 must be set for a sample to be valid;
- a valid sample is decoded as `temperature_c = (raw & 0xFFFF) / 256.0`.

The module intentionally returns the six raw DWORDs. Validation and temperature conversion remain the responsibility of the userspace consumer.

## Motivation

Recent NVIDIA drivers no longer expose a reliable RTX 50 hotspot value through the interface previously used by monitoring plugins. HWMonitor 1.65.1 obtains the value through these GB202 BAR0 registers rather than through an ordinary NVAPI thermal call.

The intended consumer is a free FanControl plugin. GPU core and GDDR7 memory-junction temperatures have been independently validated through `NvAPI_GPU_GetThermalSensors` on the same RTX 5090 and will remain in userspace; PawnIO is needed only for the Blackwell thermal channels unavailable through that interface.

## Safety constraints

The module is deliberately device-specific and read-only. It rejects every PCI device other than `10DE:2B85` and does not expose arbitrary offsets or addresses to userspace. All six DWORD offsets are constants in the signed module.

## Validation performed

- Compiles with Pawn compiler 4.1.7152 using the repository CI flags, with no warnings.
- Source review confirms that no write primitive is used.
- Static comparison of HWMonitor 1.65 and 1.65.1 confirms the corrected register set, validity test, and scale factor.
- The target machine identifies the GPU as `10DE:2B85` at `0000:01:00.0`.
- The unsigned module is rejected by official PawnIO 2.2.0 as expected.

An actual register read with this exact module remains pending because the test system has Secure Boot enabled and official PawnIO accepts only signed modules. The owner of the tested RTX 5090 Founders Edition is available to compare a signed test build with HWMonitor 1.65.1 at idle and under load.

## Scope

This PR contains only `NvidiaGB202Thermal.p`. It does not include proprietary CPUID binaries, disassembly output, memory dumps, logs, or experimental userspace probes.
