### PR TITLE
AMDFamily17: allow read-only MCA/SMCA diagnostics

### DIFF
--- a/AMDFamily17.p
+++ b/AMDFamily17.p
@@ -21,8 +21,30 @@
 
 #define MSR_AMD64_PATCH_LEVEL       (0x0000008B)
 
+#define MSR_MCG_CAP                 (0x00000179)
+#define MSR_MCG_STATUS              (0x0000017A)
+#define MSR_MCG_CTL                 (0x0000017B)
+
 #define MSR_MPERF_RO                (0xC00000E7)
 #define MSR_APERF_RO                (0xC00000E8)
+
+#define MSR_AMD64_SMCA_BASE         (0xC0002000)
+#define MSR_AMD64_SMCA_END          (0xC00023FF)
+#define SMCA_REGS_PER_BANK          (0x10)
+#define SMCA_BANK_COUNT_MASK        (0xFF)
+
+#define SMCA_CTL_OFFSET             (0x00)
+#define SMCA_STATUS_OFFSET          (0x01)
+#define SMCA_ADDR_OFFSET            (0x02)
+#define SMCA_MISC0_OFFSET           (0x03)
+#define SMCA_CONFIG_OFFSET          (0x04)
+#define SMCA_IPID_OFFSET            (0x05)
+#define SMCA_SYND_OFFSET            (0x06)
+#define SMCA_DESTAT_OFFSET          (0x08)
+#define SMCA_DEADDR_OFFSET          (0x09)
+#define SMCA_MISC1_OFFSET           (0x0A)
+#define SMCA_SYND1_OFFSET           (0x0E)
+#define SMCA_SYND2_OFFSET           (0x0F)
 
 #define MSR_K7_EVNTSEL0             (0xC0010000)
 #define MSR_K7_PERFCTR0             (0xC0010004)
@@ -64,8 +86,30 @@
 #define SMN_DATA_OFFSET		(0x64)
 
 bool:is_allowed_msr_read(msr) {
+    // SMCA dedicates sixteen MSRs to each bank. Restrict access to the
+    // architected diagnostic registers of banks reported by MCG_CAP.
+    if (msr >= MSR_AMD64_SMCA_BASE && msr <= MSR_AMD64_SMCA_END) {
+        new mcg_cap = 0;
+        if (!NT_SUCCESS(msr_read(MSR_MCG_CAP, mcg_cap)))
+            return false;
+
+        new bank = (msr - MSR_AMD64_SMCA_BASE) / SMCA_REGS_PER_BANK;
+        if (bank >= (mcg_cap & SMCA_BANK_COUNT_MASK))
+            return false;
+
+        switch (msr & (SMCA_REGS_PER_BANK - 1)) {
+            case SMCA_CTL_OFFSET, SMCA_STATUS_OFFSET, SMCA_ADDR_OFFSET,
+                 SMCA_MISC0_OFFSET, SMCA_CONFIG_OFFSET, SMCA_IPID_OFFSET,
+                 SMCA_SYND_OFFSET, SMCA_DESTAT_OFFSET, SMCA_DEADDR_OFFSET,
+                 SMCA_MISC1_OFFSET, SMCA_SYND1_OFFSET, SMCA_SYND2_OFFSET:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     switch (msr) {
-        case MSR_AMD64_PATCH_LEVEL,
+        case MSR_AMD64_PATCH_LEVEL, MSR_MCG_CAP, MSR_MCG_STATUS, MSR_MCG_CTL,
              MSR_MPERF_RO, MSR_APERF_RO,
              MSR_K7_EVNTSEL0, MSR_K7_PERFCTR0, MSR_K7_HWCR,
              MSR_PSTATE_CURRENT_LIMIT, MSR_PSTATE_STATUS,


### PR DESCRIPTION
## What

Extend the existing `AMDFamily17.ioctl_read_msr` allow-list with read-only AMD MCA/SMCA diagnostics:

- global `MCG_CAP`, `MCG_STATUS`, and `MCG_CTL`;
- the architected per-bank `CTL`, `STATUS`, `ADDR`, `MISC0`, `CONFIG`, `IPID`, `SYND`, `DESTAT`, `DEADDR`, `MISC1`, `SYND1`, and `SYND2` registers in `MSRC000_2[3FF:000]`;
- runtime validation that the requested bank is below `MCG_CAP.Count`;
- rejection of reserved bank offsets and banks not reported by the processor.

No new IOCTL or ABI is introduced.

## Why

The SMCA error banks are the hardware-facing source for machine-check diagnostics on AMD Family 17h through 1Ah. In particular, software can identify UMC banks through `MCA_IPID.HardwareID` and inspect their status, address, syndrome, and deferred-error records without relying on WHEA event delivery.

Making these documented registers readable through PawnIO gives diagnostics and stability tools a narrow, signed alternative to unrestricted WinRing0-style MSR drivers.

## Safety and compatibility

- Read-only: `is_allowed_msr_write` is unchanged, so status clearing and MCA reconfiguration are not exposed.
- No arbitrary MSR range: only the documented diagnostic offsets are accepted.
- Each bank is checked against the processor-reported `MCG_CAP.Count` before the requested MSR is read.
- The module's existing AMD vendor, x64, and Family 17h-1Ah gates still apply.
- Existing callers and IOCTL layouts are unchanged.

## References

- AMD, *Open-Source Register Reference for AMD Family 17h Processors*, Machine Check Architecture / Scalable MCA: https://www.amd.com/content/dam/amd/en/documents/processor-tech-docs/programmer-references/56255_OSRR.pdf
- AMD openSIL, SMCA register layout and offsets: https://github.com/openSIL/openSIL/blob/2043ec6c7db5892eba319beeeb85861231153713/xUSL/RAS/Common/RasReg.h
- AMD openSIL, reference MCA error collection (including UMC-only `MISC1`, `SYND1`, and `SYND2`): https://github.com/openSIL/openSIL/blob/2043ec6c7db5892eba319beeeb85861231153713/xPRF/RAS/xPrfRas.c

## Checks

- `pawncc AMDFamily17.p '-iinclude' '-C64' '-;+' '-(+' '-p'` using the repository's Pawn 4.1.7152 package: completed successfully with no warnings.
- `git diff --check`: clean.