### PR TITLE
RyzenSMU: Fix Bergamo family

### DIFF
--- a/RyzenSMU.p
+++ b/RyzenSMU.p
@@ -145,6 +145,8 @@ CodeName:get_code_name(family, model, pkg_type) {
             return CPU_Phoenix2;
         case 0x197C:
             return CPU_HawkPoint;
+        case 0x19A0:
+            return CPU_Bergamo;
         // Family 1Ah
         case 0x1A02:
             return CPU_Turin;
@@ -162,8 +164,6 @@ CodeName:get_code_name(family, model, pkg_type) {
             return CPU_KrackanPoint2;
         case 0x1A70:
             return CPU_StrixHalo;
-        case 0x1AA0:
-            return CPU_Bergamo;
         default:
             return CPU_Undefined;
     }


### PR DESCRIPTION
This fixes wrong case that would never match on Bergamo CPU family as it is incorrectly listed as 1Ah family.
Bergamo has CPUID of 0xAA0F02 which decodes to:

```
family: FAMILY_19H (19h)
base model: 0x0
ext. model: 0xA
model: 0xA0
stepping: 2
```

No changes are made to the order of the CodeName enum contants.

**Source**:
https://github.com/InstLatx64/InstLatx64/blob/master/AuthenticAMD/AuthenticAMD0AA0F02_K19_Bergamo_04_CPUID.txt

Verified to compile with Pawn compiler 4.1.7152, but unfortunately no way for me to check on real hardware.