### PR TITLE
SmbusI801: Fix missing bitmask

### DIFF
--- a/SmbusI801.p
+++ b/SmbusI801.p
@@ -601,9 +601,11 @@ NTSTATUS:i801_inuse(bool:inuse)
         new deadline = get_tick_count() + MAX_TIMEOUT;
         new is_inuse;
         virtual_read_byte(SMBHSTSTS, is_inuse);
+        is_inuse &= SMBHSTSTS_INUSE_STS;
         while (is_inuse && (get_tick_count() < deadline)) {
             microsleep(250);
             virtual_read_byte(SMBHSTSTS, is_inuse);
+            is_inuse &= SMBHSTSTS_INUSE_STS;
         }
 
         if (is_inuse) {


### PR DESCRIPTION
Hi, this hopefully fixes #90.

Also, should we check that `SMBHSTSTS` is not `0xff` during `i801_init`? I'm unsure if it's impossible for all the status bits to be set, but it's definitely unlikely; as it seems it would require multiple errors to have occurred, software to not clear any status flags, and the controller being currently busy.