### PR TITLE
Validate the NCT6793 SMBus base before I/O

### DIFF
--- a/SmbusNCT6793.p
+++ b/SmbusNCT6793.p
@@ -62,8 +62,13 @@
 
 #define SIO_REG_LDSEL               0x07    /* Logical device select            */
 #define SIO_REG_DEVID               0x20    /* Device ID (2 bytes)              */
+#define SIO_REG_ENABLE              0x30    /* Logical device enable            */
 #define SIO_REG_SMBA                0x62    /* SMBus base address register      */
 #define SIO_REG_LOGDEV              0x07    /* Logical Device Register          */
+
+#define SMBUS_IO_LAST_OFFSET        0x0E
+#define PCI_CONFIG_ADDRESS_PORT     0xCF8
+#define PCI_CONFIG_DATA_PORT_END    0xCFF
 
 #define SIO_NCT6791_ID              0xc800
 #define SIO_NCT6792_ID              0xc910
@@ -171,15 +176,23 @@ NTSTATUS:nct6793_init()
     /* Enable SMBus logical device */
     superio_outb(sioaddr, SIO_REG_LOGDEV, NCT6793_LD_SMBUS);
 
+    new bool:smba_enabled = (superio_inb(sioaddr, SIO_REG_ENABLE) & BIT(0)) != 0;
+
     /* Determine base address */
     new smba = (superio_inb(sioaddr, SIO_REG_SMBA) << 8) | superio_inb(sioaddr, SIO_REG_SMBA + 1);
+    new smba_verify = (superio_inb(sioaddr, SIO_REG_SMBA) << 8) | superio_inb(sioaddr, SIO_REG_SMBA + 1);
+    new bool:smba_stable = smba == smba_verify;
 
-    /* Align it the way the Super IO decoder does, then refuse a base of zero.
-       Without this a disabled or unprogrammed logical device would aim every
-       later access at legacy ports 0x00-0x0E, which is the DMA controller. */
+    /* Align the base the way the Super IO decoder does, then require the full
+       controller register window to be a usable 16-bit I/O range. */
     smba &= ~7;
 
-    if(smba == 0)
+    if( !smba_enabled
+     || !smba_stable
+     || smba < 0x100
+     || smba == 0xFFF8
+     || smba > (0xFFFF - SMBUS_IO_LAST_OFFSET)
+     || (smba <= PCI_CONFIG_DATA_PORT_END && (smba + SMBUS_IO_LAST_OFFSET) >= PCI_CONFIG_ADDRESS_PORT))
     {
         return STATUS_NOT_SUPPORTED;
     }


### PR DESCRIPTION
## Problem

NCT6793 initialization currently trusts any nonzero SMBus base reported by logical device 0x0B after alignment. It does not verify that the logical device is active or that repeated base reads are stable. An unprogrammed `0xFFFF` value aligns to `0xFFF8`; accesses at offsets `0x09` and `0x0E` then exceed the 16-bit I/O-port range and are truncated by the native layer.

## Change

- require logical device 0x0B to be enabled
- read the raw SMBus base twice and require a stable value
- align only after capturing the raw values
- reject fixed/legacy space below `0x100`, the unprogrammed top window, 16-bit window overflow, and overlap with PCI configuration ports `0xCF8-0xCFF`
- keep all failures on the pre-existing single invalid-base return so this composes safely with the separate Super-I/O-exit fix

Companion cleanup: #102.

## Verification

- Pawn 4.1.7152 compile with the repository CI flags: pass
- boundary/source invariant checks: pass
- `git diff --check`: pass
- clean merge-tree with the Super-I/O-exit branch; every post-enter return exits configuration mode
- detached aggregate compile with all reviewed i801/NCT fixes: pass

No live port I/O was issued during verification.
