### PR TITLE
Fix i801 block-process response layout

### DIFF
--- a/SmbusI801.p
+++ b/SmbusI801.p
@@ -981,8 +981,6 @@ DEFINE_IOCTL(ioctl_smbus_xfer) {
             if (!NT_SUCCESS(status))
                 goto getout;
 
-            // Keep the same output ABI as SMBus and I2C block reads:
-            // one full cell for the length, followed by byte-packed data.
             out[0] = out_data[0];
             pack_bytes_le(out_data, out, I2C_SMBUS_BLOCK_MAX, 1, 8);
         }

--- a/SmbusI801.p
+++ b/SmbusI801.p
@@ -981,7 +981,10 @@ DEFINE_IOCTL(ioctl_smbus_xfer) {
             if (!NT_SUCCESS(status))
                 goto getout;
 
-            pack_bytes_le(out_data, out, I2C_SMBUS_BLOCK_MAX + 1);
+            // Keep the same output ABI as SMBus and I2C block reads:
+            // one full cell for the length, followed by byte-packed data.
+            out[0] = out_data[0];
+            pack_bytes_le(out_data, out, I2C_SMBUS_BLOCK_MAX, 1, 8);
         }
         default:
         {


### PR DESCRIPTION
## Problem

The block-process-call response is packed as 33 consecutive bytes starting at byte zero. That places the one-byte length and seven data bytes into `out[0]`, unlike the documented ABI used by the other block-read paths, where `out[0]` is a full cell containing the length and data begins at `out[1]`.

## Change

Store the returned length in `out[0]`, then pack the 32 data bytes from source byte offset 1 into destination byte offset 8.

This makes block-process-call output match the existing length-cell plus packed-data ABI.

## Verification

- Pawn 4.1.7152 compile with the repository CI flags: pass
- byte-offset/source-size invariant check: pass
- `git diff --check`: pass
- independent source/control-flow cross-review: pass
- detached aggregate compile with the other i801 and NCT fixes: pass

No live transaction was issued against hardware during verification.
