### PR TITLE
Reject the NCT6793 general-call address

### DIFF
--- a/SmbusNCT6793.p
+++ b/SmbusNCT6793.p
@@ -210,7 +210,9 @@ NTSTATUS:nct6793_access(addr, read_write, command, size, in[5], out[5])
     /* Validate everything that reaches the controller before touching it. The
        soft reset below would otherwise disturb an in-flight transfer on behalf
        of a request that is about to be rejected anyway. */
-    if(addr < 0 || addr > I2C_SMBUS_ADDR_MAX)
+    /* Address zero is the I2C General Call/broadcast address, not a
+       target SMBus device address for these byte/word/block protocols. */
+    if(addr <= 0 || addr > I2C_SMBUS_ADDR_MAX)
     {
         return STATUS_INVALID_PARAMETER;
     }


### PR DESCRIPTION
## Problem

The NCT6793 transfer API accepts address zero. In I2C/SMBus this is the general-call/broadcast address, not an ordinary target-device address. The module exposes only byte, word, and block target operations, so accepting zero can broadcast caller-controlled command/data without providing a legitimate general-call operation.

## Change

Reject address zero during the existing pre-I/O validation, before the controller reset or any transaction register is touched.

## Verification

- Pawn 4.1.7152 compile with the repository CI flags: pass
- validation/source invariant check: pass
- `git diff --check`: pass
- detached aggregate compile with all reviewed i801/NCT fixes: pass

No live transaction was issued against hardware during verification.
