### PR TITLE
Exit NCT6793 Super-I/O configuration mode

### DIFF
--- a/SmbusNCT6793.p
+++ b/SmbusNCT6793.p
@@ -108,6 +108,11 @@ superio_enter(addr)
     io_out_byte(addr, 0x87);
 }
 
+superio_exit(addr)
+{
+    io_out_byte(addr, 0xAA);
+}
+
 superio_inb(addr, reg)
 {
     io_out_byte(addr, reg);
@@ -164,6 +169,7 @@ NTSTATUS:nct6793_init()
         
         default:
             {
+                superio_exit(sioaddr);
                 return STATUS_NOT_SUPPORTED;
             }
     }
@@ -181,10 +187,13 @@ NTSTATUS:nct6793_init()
 
     if(smba == 0)
     {
+        superio_exit(sioaddr);
         return STATUS_NOT_SUPPORTED;
     }
 
     nuvoton_nct6793_smba = smba;
+
+    superio_exit(sioaddr);
 
     /* Read initial clock setting */
     smbus_clock = (io_in_byte(SMBHSTCLK) & 0xF);


### PR DESCRIPTION
## Problem

`nct6793_init()` enters Nuvoton Super-I/O configuration mode with the `0x87, 0x87` unlock sequence but never sends the matching `0xAA` exit byte. Both failure and success leave the chip unlocked, allowing unrelated port traffic or another monitoring driver to be interpreted as configuration-register access.

## Change

Add `superio_exit()` and call it:

- before the unsupported-device return
- before the invalid-base return
- on success, before the first runtime SMBus register access

This merges cleanly with the additional validation paths in #99.

## Verification

- Pawn 4.1.7152 compile with the repository CI flags: pass
- `git diff --check`: pass
- all post-enter return paths checked in isolation: pass
- clean merge-tree with the SMBus-base validation branch: pass
- detached aggregate compile with all reviewed i801/NCT fixes: pass

No live port I/O was issued during verification.
