### PR TITLE
Fix the NCT6798 device-ID mask

### DIFF
--- a/SmbusNCT6793.p
+++ b/SmbusNCT6793.p
@@ -71,7 +71,7 @@
 #define SIO_NCT6795_ID              0xd350
 #define SIO_NCT6796_ID              0xd420
 #define SIO_NCT6798_ID              0xd428
-#define SIO_ID_MASK                 0xFFF0
+#define SIO_ID_MASK                 0xFFF8
 
 #define I2C_SMBUS_BLOCK_MAX         32      /* As specified in SMBus standard   */
 #define I2C_SMBUS_ADDR_MAX          0x7F    /* Addressing is 7 bit              */


### PR DESCRIPTION
## Problem

The current `0xFFF0` Super-I/O ID mask aliases NCT6798 IDs such as `0xD42B` to the NCT6796 family value `0xD420`. As a result, the NCT6798 case at `0xD428` is unreachable and the module reports the wrong controller identity.

## Change

Use the `0xFFF8` family mask used by the current Linux NCT6775 driver. This maps revisions `0xD428-0xD42F` to NCT6798 while retaining the existing NCT6796 family mapping.

Reference: https://github.com/torvalds/linux/blob/master/drivers/hwmon/nct6775.h

## Verification

- Pawn 4.1.7152 compile with the repository CI flags: pass
- sample family/revision mapping assertions: pass
- `git diff --check`: pass
- independent cross-review against the Linux family mask: pass
- detached aggregate compile with all reviewed i801/NCT fixes: pass

No live port I/O was issued during verification.
