### PR TITLE
Add IntelRaptorLakeOcMailbox: narrow MSR 0x150 OC-mailbox module for Raptor Lake-S

### DIFF
--- a/IntelRaptorLakeOcMailbox.p
+++ b/IntelRaptorLakeOcMailbox.p
@@ -1,0 +1,262 @@
+//  IntelRaptorLakeOcMailbox - A narrow PawnIO module for MSR 0x150 OC-mailbox
+//  voltage offsets on the tested Raptor Lake-S desktop model family.
+//
+//  Copyright (C) 2026  RaptorLakeVF contributors
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//  SPDX-License-Identifier: LGPL-2.1-or-later
+//
+//  STATUS: SOURCE ONLY. This module is NOT built, NOT signed, NOT loaded, and is
+//  NOT loadable in this repository. It is prepared for review and (later) for
+//  submission to the PawnIO maintainers. A locally built unsigned artifact is
+//  REVIEW ONLY and must never be placed where the application could discover it.
+//  The REAL build toolchain is the pinned PawnIO.Modules compiler (pawncc
+//  4.1.7152 from the `_pawn/` RPMs); the C file in this directory is an
+//  AUXILIARY syntax mirror only (gcc stub) and is NOT the module.
+//
+//  PRIVILEGED SURFACE (the only operations this module performs):
+//    ioctl_query_ia_core_offset()      -> legacy plane-offset QUERY, domain 0
+//    ioctl_query_ring_offset()         -> legacy plane-offset QUERY, domain 2
+//    ioctl_set_ia_core_neg_offset()    -> legacy plane-offset SET, domain 0
+//    ioctl_set_ring_neg_offset()       -> legacy plane-offset SET, domain 2
+//
+//  HARD INVARIANTS:
+//    - NO caller-selected MSR number. The only MSR ever accessed is 0x150
+//      (IA32_OC_MAILBOX); the internal mailbox helper rejects anything else even
+//      if called with a different address (defense in depth).
+//    - NO caller-supplied raw 64-bit request. Requests are built ONLY from the
+//      typed operations above with validated command/domain/payload fields.
+//    - Non-positive only: SET operations accept raw_steps <= 0 (zero is
+//      intentionally permitted — an exact restore state may be 0 offset —
+//      negatives are accepted) and reject positive payloads before any
+//      privileged access; the signed payload is validated against the signed
+//      11-bit representation (bits [31:21], 1/1024 V quantum).
+//    - Reserved bits outside [31:21] are rejected.
+//    - No power-limit, VR-mailbox, ratio, thermal, firmware-storage, or I/O-port
+//      access of any kind.
+//
+//  QUERY PROTOCOL EVIDENCE (4N.2): the non-mutating query packet
+//  (bit63 busy + cmd 0x10 in [39:32] + domain in [47:40]) is line-confirmed in
+//  five independent implementations (georgewhewell/undervolt,
+//  kitsunyan/intel-undervolt, wesmar/UnderVolter, subratamal/VoltageShift,
+//  xCuri0/VoltageShiftSecure); wesmar/UnderVolter CpuData.c lists family 6
+//  model 183 (0xB7) as Raptor Lake-S B0/C0 desktop — the tested i5-13600KF.
+//  RaptorLakeVF's evidence policy therefore reports the query protocol
+//  Supported; live execution is still separately gated (signed module + platform
+//  proof) and never happens in this repository.
+
+#include <pawnio.inc>
+
+// The ONLY writable MSR this module ever touches.
+#define RAPTORLAKEVF_ONLY_MSR 0x150
+
+// Legacy global-offset OC-mailbox packet fields (source-golden, 4N.2
+// line-confirmed across five independent implementations).
+#define OC_MAILBOX_REQUEST_BUSY_BIT (1 << 63)
+#define OC_MAILBOX_COMMAND_MASK     (0xFF << 32)
+#define OC_MAILBOX_QUERY_COMMAND    (0x10 << 32)
+#define OC_MAILBOX_SET_COMMAND      (0x11 << 32)
+#define OC_MAILBOX_OFFSET_MASK      0xFFE00000          // bits [31:21]
+#define OC_MAILBOX_DOMAIN_IA_CORE   0
+#define OC_MAILBOX_DOMAIN_RING      2
+
+// CPU family/model gate (Milestone 4N.1/4N.2). The first proposed release is
+// gated to the tested Raptor Lake-S model family: family 6, model 0xB7 (183),
+// stepping 1 — the tested i5-13600KF (0xB7/1 = RPL-S B0 per wesmar/UnderVolter
+// CpuData.c). The gate is FAIL-CLOSED: only the evidenced stepping is accepted.
+// It is never broadened to every Intel CPU.
+#define RAPTORLAKEVF_GATED_FAMILY 6
+#define RAPTORLAKEVF_GATED_MODEL 0xB7
+#define RAPTORLAKEVF_GATED_STEPPING 1
+
+// Bounded busy-poll budget (same order as the independent implementations).
+#define OC_MAILBOX_MAX_SPINS 8
+
+/// Validate the CPU gate (family 6, model 0xB7, stepping 1).
+stock bool:cpu_gate_ok() {
+    new fms = get_cpu_fms();
+    return cpu_fms_family(fms) == RAPTORLAKEVF_GATED_FAMILY
+        && cpu_fms_model(fms) == RAPTORLAKEVF_GATED_MODEL
+        && cpu_fms_stepping(fms) == RAPTORLAKEVF_GATED_STEPPING;
+}
+
+/// Send one OC-mailbox packet to MSR 0x150 and wait for the busy marker to
+/// clear, returning the raw response. Rejects any other MSR address even if
+/// called with one (defense in depth: no caller-selected MSR can ever reach a
+/// privileged write).
+stock NTSTATUS:mailbox_send(msr, value, &response) {
+    if (msr != RAPTORLAKEVF_ONLY_MSR)
+        return STATUS_ACCESS_DENIED;
+
+    new NTSTATUS:status = msr_write(msr, value);
+    if (status != STATUS_SUCCESS)
+        return status;
+
+    new i;
+    for (i = 0; i < OC_MAILBOX_MAX_SPINS; i++) {
+        new r = 0;
+        status = msr_read(msr, r);
+        if (status != STATUS_SUCCESS)
+            return status;
+        if ((r & OC_MAILBOX_REQUEST_BUSY_BIT) == 0) {
+            response = r;
+            return STATUS_SUCCESS;
+        }
+        microsleep(50);
+    }
+    return STATUS_TIMEOUT;
+}
+
+/// Build the legacy global-offset packet. Only the two typed domains and the
+/// two typed commands exist; the signed payload must be pre-validated and must
+/// only set bits [31:21].
+stock NTSTATUS:build_legacy_packet(domain, command, payload, &packet) {
+    if (domain != OC_MAILBOX_DOMAIN_IA_CORE && domain != OC_MAILBOX_DOMAIN_RING)
+        return STATUS_INVALID_PARAMETER;
+    if (command != OC_MAILBOX_QUERY_COMMAND && command != OC_MAILBOX_SET_COMMAND)
+        return STATUS_INVALID_PARAMETER;
+    if ((payload & ~OC_MAILBOX_OFFSET_MASK) != 0)
+        return STATUS_INVALID_PARAMETER;
+    packet = OC_MAILBOX_REQUEST_BUSY_BIT | (domain << 40) | command | payload;
+    return STATUS_SUCCESS;
+}
+
+/// Non-positive signed payload check: raw_steps must be <= 0 (zero accepted —
+/// an exact restore state may be 0 offset — negative accepted) and within the
+/// signed 11-bit representation. Positive values are rejected. Returns the
+/// [31:21] payload via `payload`.
+stock NTSTATUS:validate_negative_steps(raw_steps, &payload) {
+    if (raw_steps > 0)
+        return STATUS_INVALID_PARAMETER;
+    if (raw_steps < -1024)
+        return STATUS_INVALID_PARAMETER;
+    payload = (raw_steps << 21) & OC_MAILBOX_OFFSET_MASK;
+    return STATUS_SUCCESS;
+}
+
+/// Query the legacy IA-core offset (domain 0).
+/// @param in_size Must be 0
+/// @param out [0] = raw mailbox response
+/// @param out_size Must be 1
+/// @return An NTSTATUS
+DEFINE_IOCTL_SIZED(ioctl_query_ia_core_offset, 0, 1) {
+    if (!cpu_gate_ok())
+        return STATUS_NOT_SUPPORTED;
+
+    new packet = 0;
+    new NTSTATUS:status = build_legacy_packet(OC_MAILBOX_DOMAIN_IA_CORE, OC_MAILBOX_QUERY_COMMAND, 0, packet);
+    if (status != STATUS_SUCCESS)
+        return status;
+
+    new response = 0;
+    status = mailbox_send(RAPTORLAKEVF_ONLY_MSR, packet, response);
+    out[0] = response;
+    return status;
+}
+
+/// Query the legacy Ring/Cache offset (domain 2).
+/// @param in_size Must be 0
+/// @param out [0] = raw mailbox response
+/// @param out_size Must be 1
+/// @return An NTSTATUS
+DEFINE_IOCTL_SIZED(ioctl_query_ring_offset, 0, 1) {
+    if (!cpu_gate_ok())
+        return STATUS_NOT_SUPPORTED;
+
+    new packet = 0;
+    new NTSTATUS:status = build_legacy_packet(OC_MAILBOX_DOMAIN_RING, OC_MAILBOX_QUERY_COMMAND, 0, packet);
+    if (status != STATUS_SUCCESS)
+        return status;
+
+    new response = 0;
+    status = mailbox_send(RAPTORLAKEVF_ONLY_MSR, packet, response);
+    out[0] = response;
+    return status;
+}
+
+/// Set a non-positive IA-core offset (domain 0). The caller supplies RAW STEPS
+/// (<= 0 — zero accepted for an exact restore-to-0 state — within the signed
+/// 11-bit range); the module encodes bits [31:21].
+/// @param in [0] = raw steps (non-positive)
+/// @param in_size Must be 1
+/// @param out [0] = raw mailbox response
+/// @param out_size Must be 1
+/// @return An NTSTATUS
+DEFINE_IOCTL_SIZED(ioctl_set_ia_core_neg_offset, 1, 1) {
+    if (!cpu_gate_ok())
+        return STATUS_NOT_SUPPORTED;
+
+    new raw_steps = in[0];
+    new payload = 0;
+    new NTSTATUS:status = validate_negative_steps(raw_steps, payload);
+    if (status != STATUS_SUCCESS)
+        return status;
+
+    new packet = 0;
+    status = build_legacy_packet(OC_MAILBOX_DOMAIN_IA_CORE, OC_MAILBOX_SET_COMMAND, payload, packet);
+    if (status != STATUS_SUCCESS)
+        return status;
+
+    new response = 0;
+    // Mutation is never retried silently: the busy timeout or unexpected
+    // response is returned to the caller as an explicit failure.
+    status = mailbox_send(RAPTORLAKEVF_ONLY_MSR, packet, response);
+    out[0] = response;
+    return status;
+}
+
+/// Set a non-positive Ring/Cache offset (domain 2). The caller supplies RAW STEPS
+/// (<= 0 — zero accepted for an exact restore-to-0 state — within the signed
+/// 11-bit range); the module encodes bits [31:21].
+/// @param in [0] = raw steps (non-positive)
+/// @param in_size Must be 1
+/// @param out [0] = raw mailbox response
+/// @param out_size Must be 1
+/// @return An NTSTATUS
+DEFINE_IOCTL_SIZED(ioctl_set_ring_neg_offset, 1, 1) {
+    if (!cpu_gate_ok())
+        return STATUS_NOT_SUPPORTED;
+
+    new raw_steps = in[0];
+    new payload = 0;
+    new NTSTATUS:status = validate_negative_steps(raw_steps, payload);
+    if (status != STATUS_SUCCESS)
+        return status;
+
+    new packet = 0;
+    status = build_legacy_packet(OC_MAILBOX_DOMAIN_RING, OC_MAILBOX_SET_COMMAND, payload, packet);
+    if (status != STATUS_SUCCESS)
+        return status;
+
+    new response = 0;
+    status = mailbox_send(RAPTORLAKEVF_ONLY_MSR, packet, response);
+    out[0] = response;
+    return status;
+}
+
+NTSTATUS:main() {
+    if (get_arch() != ARCH_X64)
+        return STATUS_NOT_SUPPORTED;
+
+    if (get_cpu_vendor() != CpuVendor_Intel)
+        return STATUS_NOT_SUPPORTED;
+
+    // Fail closed on any CPU outside the evidenced model/stepping.
+    if (!cpu_gate_ok())
+        return STATUS_NOT_SUPPORTED;
+
+    return STATUS_SUCCESS;
+}

--- a/IntelRaptorLakeOcMailbox.p
+++ b/IntelRaptorLakeOcMailbox.p
@@ -19,52 +19,73 @@
 //
 //  SPDX-License-Identifier: LGPL-2.1-or-later
 //
-//  STATUS: SOURCE ONLY. This module is NOT built, NOT signed, NOT loaded, and is
-//  NOT loadable in this repository. It is prepared for review and (later) for
-//  submission to the PawnIO maintainers. A locally built unsigned artifact is
-//  REVIEW ONLY and must never be placed where the application could discover it.
-//  The REAL build toolchain is the pinned PawnIO.Modules compiler (pawncc
-//  4.1.7152 from the `_pawn/` RPMs); the C file in this directory is an
-//  AUXILIARY syntax mirror only (gcc stub) and is NOT the module.
+//  PURPOSE
+//  -------
+//  Provides typed access to the Intel OC-mailbox (MSR 0x150) used by
+//  Raptor Lake-S undervolting: read the legacy global voltage offset for the
+//  IA/Core and Ring/Cache planes, and set a non-positive offset on either
+//  plane. The surface is intentionally narrow: four typed operations, no
+//  caller-selected MSR, domain, command, or raw mailbox packet.
+//
+//  SUPPORTED CPU SCOPE
+//  -------------------
+//  Family 6, model 0xB7 (183), stepping 1 — Intel Core i5-13600KF (Raptor
+//  Lake-S B0 desktop). The module refuses to load on any other CPU.
 //
 //  PRIVILEGED SURFACE (the only operations this module performs):
-//    ioctl_query_ia_core_offset()      -> legacy plane-offset QUERY, domain 0
-//    ioctl_query_ring_offset()         -> legacy plane-offset QUERY, domain 2
-//    ioctl_set_ia_core_neg_offset()    -> legacy plane-offset SET, domain 0
-//    ioctl_set_ring_neg_offset()       -> legacy plane-offset SET, domain 2
+//    ioctl_query_ia_core_offset()      -> OC-mailbox QUERY, domain 0 (IA/Core)
+//    ioctl_query_ring_offset()         -> OC-mailbox QUERY, domain 2 (Ring/Cache)
+//    ioctl_set_ia_core_neg_offset()    -> OC-mailbox SET, domain 0 (IA/Core)
+//    ioctl_set_ring_neg_offset()       -> OC-mailbox SET, domain 2 (Ring/Cache)
 //
-//  HARD INVARIANTS:
-//    - NO caller-selected MSR number. The only MSR ever accessed is 0x150
-//      (IA32_OC_MAILBOX); the internal mailbox helper rejects anything else even
-//      if called with a different address (defense in depth).
-//    - NO caller-supplied raw 64-bit request. Requests are built ONLY from the
+//  PROTOCOL FIELDS (legacy global-offset OC-mailbox packet, MSR 0x150)
+//  ------------------------------------------------------------------
+//    bit 63         request/busy marker
+//    bits [47:40]   domain (0 = IA/Core, 2 = Ring/Cache)
+//    bits [39:32]   command (0x10 = query/read, 0x11 = set/write)
+//    bits [31:21]   signed offset payload, 1/1024 V per step
+//
+//  SET accepts NON-POSITIVE raw steps only (raw_steps <= 0): zero is accepted
+//  (an exact restore state may be 0 offset) and negatives are accepted;
+//  positive values are rejected before any privileged access.
+//
+//  RESPONSE SEMANTICS
+//  ------------------
+//  Every IOCTL returns the raw 64-bit mailbox response cell. The module does
+//  NOT decode or verify the response: interpretation (e.g. decoding the offset
+//  field, comparing a readback) is performed by the userspace typed transport
+//  that calls this module.
+//
+//  SECURITY RESTRICTIONS
+//  ---------------------
+//    - Only MSR 0x150 is ever accessed; the mailbox helper rejects any other
+//      address even if called with one (defense in depth).
+//    - No caller-supplied raw 64-bit request: packets are built only from the
 //      typed operations above with validated command/domain/payload fields.
-//    - Non-positive only: SET operations accept raw_steps <= 0 (zero is
-//      intentionally permitted — an exact restore state may be 0 offset —
-//      negatives are accepted) and reject positive payloads before any
-//      privileged access; the signed payload is validated against the signed
-//      11-bit representation (bits [31:21], 1/1024 V quantum).
-//    - Reserved bits outside [31:21] are rejected.
-//    - No power-limit, VR-mailbox, ratio, thermal, firmware-storage, or I/O-port
-//      access of any kind.
+//    - No power-limit, VR-mailbox, ratio, thermal, firmware-storage, or I/O
+//      access; no OC-lock/UVP/CFG-lock bypass; no security-state access.
+//    - Bounded busy polling (8 spins, 50 us sleep); a timeout is an explicit
+//      failure; mutations are never retried silently.
 //
-//  QUERY PROTOCOL EVIDENCE (4N.2): the non-mutating query packet
-//  (bit63 busy + cmd 0x10 in [39:32] + domain in [47:40]) is line-confirmed in
-//  five independent implementations (georgewhewell/undervolt,
-//  kitsunyan/intel-undervolt, wesmar/UnderVolter, subratamal/VoltageShift,
-//  xCuri0/VoltageShiftSecure); wesmar/UnderVolter CpuData.c lists family 6
-//  model 183 (0xB7) as Raptor Lake-S B0/C0 desktop — the tested i5-13600KF.
-//  RaptorLakeVF's evidence policy therefore reports the query protocol
-//  Supported; live execution is still separately gated (signed module + platform
-//  proof) and never happens in this repository.
+//  SOURCE REFERENCES
+//  -----------------
+//  The packet layout is corroborated by independent implementations:
+//    - georgewhewell/undervolt (2d825f96): undervolt.py pack_offset()
+//    - kitsunyan/intel-undervolt (ea0e74c5): undervolt.c (rdval/wrval)
+//    - wesmar/UnderVolter (716df96a): VfCurve.c, OcMailbox.c, CpuData.c
+//    - subratamal/VoltageShift (33aab6ae), xCuri0/VoltageShiftSecure
+//      (6b4612c0): main.mm writeOCMailBox/readOCMailBox
+//  wesmar/UnderVolter CpuData.c lists family 6 model 183 (0xB7) as
+//  "RaptorLake" RPL-S B0 desktop (B0700) — an exact match for this module's
+//  tested target.
 
 #include <pawnio.inc>
 
 // The ONLY writable MSR this module ever touches.
-#define RAPTORLAKEVF_ONLY_MSR 0x150
+#define OC_MAILBOX_MSR 0x150
 
-// Legacy global-offset OC-mailbox packet fields (source-golden, 4N.2
-// line-confirmed across five independent implementations).
+// Legacy global-offset OC-mailbox packet fields (corroborated by the
+// independent implementations listed above).
 #define OC_MAILBOX_REQUEST_BUSY_BIT (1 << 63)
 #define OC_MAILBOX_COMMAND_MASK     (0xFF << 32)
 #define OC_MAILBOX_QUERY_COMMAND    (0x10 << 32)
@@ -73,14 +94,13 @@
 #define OC_MAILBOX_DOMAIN_IA_CORE   0
 #define OC_MAILBOX_DOMAIN_RING      2
 
-// CPU family/model gate (Milestone 4N.1/4N.2). The first proposed release is
-// gated to the tested Raptor Lake-S model family: family 6, model 0xB7 (183),
-// stepping 1 — the tested i5-13600KF (0xB7/1 = RPL-S B0 per wesmar/UnderVolter
-// CpuData.c). The gate is FAIL-CLOSED: only the evidenced stepping is accepted.
-// It is never broadened to every Intel CPU.
-#define RAPTORLAKEVF_GATED_FAMILY 6
-#define RAPTORLAKEVF_GATED_MODEL 0xB7
-#define RAPTORLAKEVF_GATED_STEPPING 1
+// Supported CPU scope: family 6, model 0xB7 (183), stepping 1 — the tested
+// Intel Core i5-13600KF (Raptor Lake-S B0 desktop). The gate is FAIL-CLOSED:
+// only the tested stepping is accepted, and it is never broadened to every
+// Intel CPU.
+#define SUPPORTED_CPU_FAMILY 6
+#define SUPPORTED_CPU_MODEL 0xB7
+#define SUPPORTED_CPU_STEPPING 1
 
 // Bounded busy-poll budget (same order as the independent implementations).
 #define OC_MAILBOX_MAX_SPINS 8
@@ -88,17 +108,18 @@
 /// Validate the CPU gate (family 6, model 0xB7, stepping 1).
 stock bool:cpu_gate_ok() {
     new fms = get_cpu_fms();
-    return cpu_fms_family(fms) == RAPTORLAKEVF_GATED_FAMILY
-        && cpu_fms_model(fms) == RAPTORLAKEVF_GATED_MODEL
-        && cpu_fms_stepping(fms) == RAPTORLAKEVF_GATED_STEPPING;
+    return cpu_fms_family(fms) == SUPPORTED_CPU_FAMILY
+        && cpu_fms_model(fms) == SUPPORTED_CPU_MODEL
+        && cpu_fms_stepping(fms) == SUPPORTED_CPU_STEPPING;
 }
 
 /// Send one OC-mailbox packet to MSR 0x150 and wait for the busy marker to
 /// clear, returning the raw response. Rejects any other MSR address even if
 /// called with one (defense in depth: no caller-selected MSR can ever reach a
-/// privileged write).
+/// privileged write). The response is returned RAW — the module does not
+/// interpret its contents; that is the caller's responsibility.
 stock NTSTATUS:mailbox_send(msr, value, &response) {
-    if (msr != RAPTORLAKEVF_ONLY_MSR)
+    if (msr != OC_MAILBOX_MSR)
         return STATUS_ACCESS_DENIED;
 
     new NTSTATUS:status = msr_write(msr, value);
@@ -138,7 +159,7 @@ stock NTSTATUS:build_legacy_packet(domain, command, payload, &packet) {
 /// an exact restore state may be 0 offset — negative accepted) and within the
 /// signed 11-bit representation. Positive values are rejected. Returns the
 /// [31:21] payload via `payload`.
-stock NTSTATUS:validate_negative_steps(raw_steps, &payload) {
+stock NTSTATUS:validate_non_positive_steps(raw_steps, &payload) {
     if (raw_steps > 0)
         return STATUS_INVALID_PARAMETER;
     if (raw_steps < -1024)
@@ -148,6 +169,8 @@ stock NTSTATUS:validate_negative_steps(raw_steps, &payload) {
 }
 
 /// Query the legacy IA-core offset (domain 0).
+/// The raw mailbox response is returned in out[0]; decoding/verification is
+/// performed by the userspace typed transport.
 /// @param in_size Must be 0
 /// @param out [0] = raw mailbox response
 /// @param out_size Must be 1
@@ -162,12 +185,14 @@ DEFINE_IOCTL_SIZED(ioctl_query_ia_core_offset, 0, 1) {
         return status;
 
     new response = 0;
-    status = mailbox_send(RAPTORLAKEVF_ONLY_MSR, packet, response);
+    status = mailbox_send(OC_MAILBOX_MSR, packet, response);
     out[0] = response;
     return status;
 }
 
 /// Query the legacy Ring/Cache offset (domain 2).
+/// The raw mailbox response is returned in out[0]; decoding/verification is
+/// performed by the userspace typed transport.
 /// @param in_size Must be 0
 /// @param out [0] = raw mailbox response
 /// @param out_size Must be 1
@@ -182,14 +207,15 @@ DEFINE_IOCTL_SIZED(ioctl_query_ring_offset, 0, 1) {
         return status;
 
     new response = 0;
-    status = mailbox_send(RAPTORLAKEVF_ONLY_MSR, packet, response);
+    status = mailbox_send(OC_MAILBOX_MSR, packet, response);
     out[0] = response;
     return status;
 }
 
 /// Set a non-positive IA-core offset (domain 0). The caller supplies RAW STEPS
 /// (<= 0 — zero accepted for an exact restore-to-0 state — within the signed
-/// 11-bit range); the module encodes bits [31:21].
+/// 11-bit range); the module encodes bits [31:21]. The raw mailbox response is
+/// returned in out[0]; the caller is responsible for readback verification.
 /// @param in [0] = raw steps (non-positive)
 /// @param in_size Must be 1
 /// @param out [0] = raw mailbox response
@@ -201,7 +227,7 @@ DEFINE_IOCTL_SIZED(ioctl_set_ia_core_neg_offset, 1, 1) {
 
     new raw_steps = in[0];
     new payload = 0;
-    new NTSTATUS:status = validate_negative_steps(raw_steps, payload);
+    new NTSTATUS:status = validate_non_positive_steps(raw_steps, payload);
     if (status != STATUS_SUCCESS)
         return status;
 
@@ -211,16 +237,19 @@ DEFINE_IOCTL_SIZED(ioctl_set_ia_core_neg_offset, 1, 1) {
         return status;
 
     new response = 0;
-    // Mutation is never retried silently: the busy timeout or unexpected
-    // response is returned to the caller as an explicit failure.
-    status = mailbox_send(RAPTORLAKEVF_ONLY_MSR, packet, response);
+    // Mutation is never retried silently: a busy timeout is returned as an
+    // explicit failure. The raw response is returned for caller-side
+    // verification; the module does not claim success from a status field.
+    status = mailbox_send(OC_MAILBOX_MSR, packet, response);
     out[0] = response;
     return status;
 }
 
-/// Set a non-positive Ring/Cache offset (domain 2). The caller supplies RAW STEPS
-/// (<= 0 — zero accepted for an exact restore-to-0 state — within the signed
-/// 11-bit range); the module encodes bits [31:21].
+/// Set a non-positive Ring/Cache offset (domain 2). The caller supplies RAW
+/// STEPS (<= 0 — zero accepted for an exact restore-to-0 state — within the
+/// signed 11-bit range); the module encodes bits [31:21]. The raw mailbox
+/// response is returned in out[0]; the caller is responsible for readback
+/// verification.
 /// @param in [0] = raw steps (non-positive)
 /// @param in_size Must be 1
 /// @param out [0] = raw mailbox response
@@ -232,7 +261,7 @@ DEFINE_IOCTL_SIZED(ioctl_set_ring_neg_offset, 1, 1) {
 
     new raw_steps = in[0];
     new payload = 0;
-    new NTSTATUS:status = validate_negative_steps(raw_steps, payload);
+    new NTSTATUS:status = validate_non_positive_steps(raw_steps, payload);
     if (status != STATUS_SUCCESS)
         return status;
 
@@ -242,7 +271,10 @@ DEFINE_IOCTL_SIZED(ioctl_set_ring_neg_offset, 1, 1) {
         return status;
 
     new response = 0;
-    status = mailbox_send(RAPTORLAKEVF_ONLY_MSR, packet, response);
+    // Mutation is never retried silently: a busy timeout is returned as an
+    // explicit failure. The raw response is returned for caller-side
+    // verification; the module does not claim success from a status field.
+    status = mailbox_send(OC_MAILBOX_MSR, packet, response);
     out[0] = response;
     return status;
 }
@@ -254,7 +286,7 @@ NTSTATUS:main() {
     if (get_cpu_vendor() != CpuVendor_Intel)
         return STATUS_NOT_SUPPORTED;
 
-    // Fail closed on any CPU outside the evidenced model/stepping.
+    // Fail closed on any CPU outside the supported family/model/stepping.
     if (!cpu_gate_ok())
         return STATUS_NOT_SUPPORTED;
 


### PR DESCRIPTION
﻿This adds a narrow PawnIO module for the Intel OC-mailbox (MSR 0x150) used by Raptor Lake-S undervolting. It exposes exactly four typed operations — query IA/Core global offset, query Ring/Cache global offset, set non-positive IA/Core offset, set non-positive Ring/Cache offset — with **no caller-selected MSR, domain, command, or raw 64-bit request**.

## Why a dedicated module instead of IntelMSR

PawnIO.Modules already exposes OC-mailbox writes through the official IntelMSR module. IntelMSR provides a broader allowlisted MSR-write interface (0x150 OC mailbox AND package power limits AND VR-configuration mailbox AND hardware-prefetch/cache control). This module intentionally **reduces the privileged surface** relative to using IntelMSR:

| | IntelMSR | IntelRaptorLakeOcMailbox |
|---|---|---|
| MSR-write interface | broader allowlist | MSR 0x150 only |
| CPU scope | any Intel | family 6 / model 0xB7 / stepping 1 only |
| Operations | caller-selected MSR + value | fixed query/set operations |
| Domains | caller-chosen | fixed (0 IA/Core, 2 Ring/Cache) |
| Caller-selected MSR | yes | no |
| Caller-selected command | yes | no |
| Raw mailbox packet | possible | no |
| Positive offset | possible | no (non-positive only) |
| Power/VR/ratio writes | possible | no |

An application that only needs the OC mailbox should not hold a module capable of other privileged writes. This reduction is the primary reason for a separate narrow module.

## Design

- MSR `0x150` only; the internal mailbox helper rejects any other address.
- CPU gate: family 6, model 0xB7, stepping 1 (the tested i5-13600KF). The module's `main()` returns `STATUS_NOT_SUPPORTED` elsewhere, so it refuses to load on unverified CPUs (per the wiki guidance to "do best effort to ensure it only runs with supported hardware"; the module itself imposes no Pawn-side lockdown).
- SET is **non-positive offset only**: `raw_steps <= 0` — zero is accepted (an exact restore state may be 0 offset) and negatives are accepted; positive offsets and reserved bits are rejected before any privileged access. Payload is checked against the signed 11-bit representation (bits [31:21], 1/1024 V step).
- Query and SET packets (0x10 / 0x11, domains 0/2) are line-confirmed against five independent implementations; see the evidence section below.
- Bounded busy polling (max 8 spins, 50 µs sleep, ~400 µs worst case); timeout fails; mutations are never retried silently.
- No OC-lock/UVP/CFG-lock bypass, no NVRAM, no firmware or security-state access of any kind. Intended for the normal restricted PawnIO driver (module signature verified against the embedded trusted-key list).

## Security context (explicit, per contribution guidelines)

Runtime OC-mailbox voltage control is **security-sensitive**: it changes CPU operating voltage, and undervolting has real security implications (it is the basis of fault-injection attacks such as Plundervolt). This module does **not** claim otherwise. It is offered so that a narrow, auditable, signed surface exists for a capability the platform already exposes.

- This module does **not** bypass Undervolt Protection (UVP), OC Lock, firmware policy, VBS/HVCI, Secure Boot, or any other security control.
- It operates only when the platform itself permits the mailbox operation; it **cannot enable a firmware-disabled capability**.
- No security-bypass operation exists in the module.
- The maintainer decides whether this security-sensitive capability meets upstream policy.

## Evidence / protocol references

The packet layout (MSR 0x150; cmd 0x10 query / 0x11 set; domain 0 IA/Core, 2 Ring/Cache; payload bits [31:21], 1/1024 V step) is line-confirmed against immutable commits of independent implementations:

- georgewhewell/undervolt `2d825f96` — `undervolt.py` `pack_offset()` / `convert_rounded_offset()` / readback `unpack_offset()`
- kitsunyan/intel-undervolt `ea0e74c5` — `undervolt.c` (~lines 52-63) rdval/wrval + readback compare
- wesmar/UnderVolter `716df96a` — `src/VfCurve.c` `IAPERF_ProbeDomainVF` / `IAPERF_ProgramDomainVF`, `src/OcMailbox.c`, `src/CpuData.c` (`{6,183,1}` "RaptorLake" RPL-S B0), `src/Platform.h` `VoltDomains`
- subratamal/VoltageShift `33aab6ae` and xCuri0/VoltageShiftSecure `6b4612c0` — `main.mm` `writeOCMailBox` / `readOCMailBox`

Tested target: Intel Core i5-13600KF, family 6, model 0xB7 (183), stepping 1 (CPUID `0x000B0671`). See also Intel's Undervolt Protection documentation (Intel support article 000094219).

## Build

Compiles with the pinned pawncc 4.1.7152, zero warnings, with the repository's `-C64` flags. Compiled AMX bytecode is audited offline (only the four typed IOCTLs exported; only the allowed natives imported; every `msr_read`/`msr_write` call is inside the 0x150-guarded helper).

## Known limitations

Only the tested Raptor Lake-S B0 stepping is gated; absolute-vs-additive mailbox semantics on this platform are unverified and require a runtime readback study; no claim of universal safety is made.