### PR TITLE
Add LpcECPMC module for the 0x68/0x6C EC PMC interface

### DIFF
--- a/LpcECPMC.p
+++ b/LpcECPMC.p
@@ -1,0 +1,72 @@
+//  PawnIO Modules - Modules for various hardware to be used with PawnIO.
+//  Copyright (C) 2026  lhzlhz419
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//  SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <pawnio.inc>
+
+// This EC PMC/OEM host-interface layout is present in various embedded
+// controller implementations, including Lenovo systems. Commands sent through
+// the interface remain vendor- and firmware-specific.
+
+is_port_allowed(port) {
+    return port == 0x68 || port == 0x6C;
+}
+
+/// Read byte from the EC PMC/OEM host interface.
+///
+/// @param in [0] = Port
+/// @param in_size Must be 1
+/// @param out [0] = Value read
+/// @param out_size Must be 1
+/// @return An NTSTATUS
+/// @warning You should acquire the "\BaseNamedObjects\Access_EC" mutant before calling this
+DEFINE_IOCTL_SIZED(ioctl_pio_read, 1, 1) {
+    new port = in[0] & 0xFFFF;
+
+    if (!is_port_allowed(port))
+        return STATUS_ACCESS_DENIED;
+
+    out[0] = io_in_byte(port);
+    return STATUS_SUCCESS;
+}
+
+/// Write byte to the EC PMC/OEM host interface.
+///
+/// @param in [0] = Port, [1] = Value
+/// @param in_size Must be 2
+/// @param out Unused
+/// @param out_size Unused
+/// @return An NTSTATUS
+/// @warning You should acquire the "\BaseNamedObjects\Access_EC" mutant before calling this
+DEFINE_IOCTL_SIZED(ioctl_pio_write, 2, 0) {
+    new port = in[0] & 0xFFFF;
+    new value = in[1];
+
+    if (!is_port_allowed(port))
+        return STATUS_ACCESS_DENIED;
+
+    if (value < 0 || value > 0xFF)
+        return STATUS_INVALID_PARAMETER;
+
+    io_out_byte(port, value);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS:main() {
+    return STATUS_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Add an `LpcECPMC` module providing byte access to an EC PMC/OEM host
interface through:

- `0x68`: data port
- `0x6C`: status/command port

The API mirrors `LpcACPIEC`, while access is strictly restricted to these
two ports.

## Background

This interface layout is present in Lenovo and various other embedded
controller implementations. It is not exclusive to a single manufacturer,
although the commands accepted through the interface may remain vendor- and
firmware-specific.

The module therefore provides only the transport mechanism and does not
contain device-specific commands or protocol assumptions.

## Safety

- Reads and writes are restricted to ports `0x68` and `0x6C`.
- Write values outside the byte range `0x00–0xFF` are rejected with
  `STATUS_INVALID_PARAMETER`.
- Other ports are rejected with `STATUS_ACCESS_DENIED`.
- The IOCTL documentation instructs callers to acquire the
  `\BaseNamedObjects\Access_EC` mutant before accessing the interface.

## References

- ITE embedded-controller documentation describes additional Power Management
  Channels with command/status and data registers.
- Public EC implementations use `0x68` as the OEM data port and `0x6C` as the
  OEM status/command port.

## Testing

- Verified against the existing `LpcACPIEC` IOCTL structure.
- Passed `git diff --check`.